### PR TITLE
docs: Add GitHub Pages documentation site

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: API Reference
+---
+
 # Docker MCP Server - API Reference
 
 **Version:** 1.0.0

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: Architecture
+---
+
 # MCP Docker Server - Architecture and Design
 
 ## Table of Contents

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: Examples
+---
+
 # Docker MCP Server - Usage Examples
 
 **Version:** 1.0.0

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: Setup Guide
+---
+
 # Setup and Installation Guide
 
 Complete guide for installing and configuring the MCP Docker server.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,28 @@
+title: MCP Docker Server
+description: A Model Context Protocol server for Docker management with AI assistants
+theme: jekyll-theme-cayman
+show_downloads: true
+
+github:
+  repository_url: https://github.com/williajm/mcp_docker
+  is_project_page: true
+
+plugins:
+  - jekyll-relative-links
+  - jekyll-optional-front-matter
+  - jekyll-readme-index
+  - jekyll-titles-from-headings
+
+relative_links:
+  enabled: true
+  collections: true
+
+titles_from_headings:
+  enabled: true
+  strip_title: true
+  collections: true
+
+markdown: kramdown
+kramdown:
+  input: GFM
+  syntax_highlighter: rouge

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,251 @@
+---
+layout: default
+title: Home
+---
+
+# MCP Docker Server Documentation
+
+[![CI](https://github.com/williajm/mcp_docker/actions/workflows/ci.yml/badge.svg)](https://github.com/williajm/mcp_docker/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/williajm/mcp_docker/branch/main/graph/badge.svg)](https://codecov.io/gh/williajm/mcp_docker)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
+[![MCP](https://img.shields.io/badge/MCP-Server-green.svg)](https://modelcontextprotocol.io)
+
+A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes Docker functionality to AI assistants like Claude. Manage containers, images, networks, and volumes through a type-safe, documented API with safety controls.
+
+## Features
+
+- **36 Docker Tools**: Complete container, image, network, volume, and system management
+- **3 AI Prompts**: Intelligent troubleshooting, optimization suggestions, and compose file generation
+- **2 Resources**: Real-time container logs and resource statistics
+- **Type Safety**: Full type hints with Pydantic validation and mypy strict mode
+- **Safety Controls**: Three-tier safety system (safe/moderate/destructive) with configurable restrictions
+- **Comprehensive Testing**: 93%+ test coverage with unit, integration, and performance tests
+- **Modern Python**: Built with Python 3.11+, uv package manager, and async-first design
+
+## Quick Links
+
+### Getting Started
+- [Setup Guide](SETUP.md) - Installation, configuration, and quick start
+- [Examples](EXAMPLES.md) - Real-world usage examples and tutorials
+
+### Reference
+- [API Reference](API.md) - Complete API documentation for all 36 tools, prompts, and resources
+- [Architecture](ARCHITECTURE.md) - Technical design, patterns, and implementation details
+
+### Resources
+- [GitHub Repository](https://github.com/williajm/mcp_docker)
+- [Issues & Bug Reports](https://github.com/williajm/mcp_docker/issues)
+- [Model Context Protocol](https://modelcontextprotocol.io)
+
+## Quick Start
+
+### Prerequisites
+
+- Python 3.11 or higher
+- Docker installed and running
+- [uv](https://github.com/astral-sh/uv) package manager (recommended) or pip
+
+### Installation
+
+#### Using uvx (Recommended)
+
+```bash
+# Run directly without installation
+uvx mcp-docker
+```
+
+#### Using uv
+
+```bash
+# Install from source
+git clone https://github.com/williajm/mcp_docker.git
+cd mcp_docker
+uv sync
+uv run mcp-docker
+```
+
+#### Using pip
+
+```bash
+# Install from PyPI (when published)
+pip install mcp-docker
+
+# Or install from source
+git clone https://github.com/williajm/mcp_docker.git
+cd mcp_docker
+pip install -e .
+```
+
+### Configuration
+
+Add to your MCP client configuration (e.g., Claude Desktop):
+
+```json
+{
+  "mcpServers": {
+    "docker": {
+      "command": "uvx",
+      "args": ["mcp-docker"],
+      "env": {
+        "DOCKER_HOST": "unix:///var/run/docker.sock"
+      }
+    }
+  }
+}
+```
+
+For Windows with named pipes:
+
+```json
+{
+  "mcpServers": {
+    "docker": {
+      "command": "uvx",
+      "args": ["mcp-docker"],
+      "env": {
+        "DOCKER_HOST": "npipe:////./pipe/docker_engine"
+      }
+    }
+  }
+}
+```
+
+## Safety System
+
+The MCP Docker server includes a three-tier safety classification system:
+
+### Safety Levels
+
+1. **SAFE** - Read-only operations with no risk
+   - List containers, images, networks, volumes
+   - Inspect resources
+   - View logs and stats
+
+2. **MODERATE** - Operations that create or modify but don't destroy
+   - Create containers, networks, volumes
+   - Start/stop/restart containers
+   - Pull images
+   - Connect/disconnect networks
+
+3. **DESTRUCTIVE** - Operations that permanently delete data
+   - Remove containers, images, networks, volumes
+   - Prune operations
+   - System cleanup
+
+### Configuration
+
+Control safety levels via environment variables:
+
+```bash
+# Allow all destructive operations
+export SAFETY_ALLOW_DESTRUCTIVE_OPERATIONS=true
+
+# Allow privileged containers
+export SAFETY_ALLOW_PRIVILEGED_CONTAINERS=true
+
+# Require confirmation for destructive operations
+export SAFETY_REQUIRE_CONFIRMATION_FOR_DESTRUCTIVE=true
+```
+
+## What's Available
+
+### 36 Docker Tools
+
+#### Container Management (10 tools)
+- List, inspect, create, start, stop, restart containers
+- View logs, execute commands, get stats
+- Remove containers
+
+#### Image Management (9 tools)
+- List, inspect, pull, build, push images
+- Tag, remove, prune images
+- View image history
+
+#### Network Management (6 tools)
+- List, inspect, create, remove networks
+- Connect/disconnect containers
+- Manage network configurations
+
+#### Volume Management (5 tools)
+- List, inspect, create, remove volumes
+- Prune unused volumes
+- Manage volume drivers
+
+#### System Operations (6 tools)
+- System info, disk usage, version
+- System-wide pruning
+- Event monitoring
+- Health checks
+
+### 3 AI Prompts
+
+1. **troubleshoot_container** - Diagnose container issues
+2. **optimize_container** - Suggest performance improvements
+3. **generate_compose** - Create docker-compose.yml files
+
+### 2 Resources
+
+1. **Container Logs** - Stream real-time logs from containers
+2. **Container Stats** - Monitor resource usage metrics
+
+## Example Usage
+
+### List All Containers
+
+```python
+# Using the MCP tool
+result = await client.call_tool("docker_list_containers", {
+    "all": True,
+    "filters": {"status": ["running"]}
+})
+```
+
+### Troubleshoot a Container
+
+```python
+# Using the AI prompt
+prompt = await client.get_prompt("troubleshoot_container", {
+    "container_id": "my-container"
+})
+# Returns detailed diagnostics and recommendations
+```
+
+### Stream Container Logs
+
+```python
+# Using the resource
+logs = await client.read_resource(
+    "container_logs://my-container?tail=100&follow=true"
+)
+```
+
+## Documentation Structure
+
+- **[Setup Guide](SETUP.md)**: Installation, configuration, and environment setup
+- **[API Reference](API.md)**: Complete tool, prompt, and resource documentation
+- **[Examples](EXAMPLES.md)**: Real-world usage scenarios and code samples
+- **[Architecture](ARCHITECTURE.md)**: Design patterns, testing strategy, and implementation
+
+## Contributing
+
+Contributions are welcome! Please see the [GitHub repository](https://github.com/williajm/mcp_docker) for:
+- Filing issues and bug reports
+- Submitting pull requests
+- Reviewing code and documentation
+
+## License
+
+MIT License - see [LICENSE](https://github.com/williajm/mcp_docker/blob/main/LICENSE) for details.
+
+## Support
+
+- **Issues**: [GitHub Issues](https://github.com/williajm/mcp_docker/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/williajm/mcp_docker/discussions)
+- **MCP Documentation**: [modelcontextprotocol.io](https://modelcontextprotocol.io)
+
+---
+
+**Version**: 1.0.0
+**Last Updated**: 2025-10-25
+**Python**: 3.11+
+**Docker**: API version 1.41+


### PR DESCRIPTION
## Summary
Configure GitHub Pages with Jekyll to create a professional documentation website for the MCP Docker server.

## Changes

### New Files
- `docs/_config.yml`: Jekyll configuration with Cayman theme
- `docs/index.md`: Comprehensive landing page with quick start guide

### Updated Files
- `docs/API.md`: Added Jekyll front matter
- `docs/ARCHITECTURE.md`: Added Jekyll front matter  
- `docs/EXAMPLES.md`: Added Jekyll front matter
- `docs/SETUP.md`: Added Jekyll front matter

## Documentation Site Structure

```
docs/
├── index.md          # Home page with overview and quick start
├── SETUP.md          # Installation and configuration guide
├── API.md            # Complete API reference (36 tools)
├── EXAMPLES.md       # Real-world usage examples
├── ARCHITECTURE.md   # Technical design documentation
└── _config.yml       # Jekyll configuration
```

## Features

### Landing Page (index.md)
- Status badges (CI, coverage, Python version, MCP)
- Feature highlights
- Quick start installation guide (uvx, uv, pip)
- Configuration examples for Windows and Unix
- Safety system overview
- Complete tool/prompt/resource listing
- Quick links to all documentation sections

### Jekyll Configuration
- **Theme**: Cayman (clean, modern, responsive)
- **Plugins**: Relative links, optional front matter, titles from headings
- **Markdown**: GitHub Flavored Markdown (GFM) with Rouge syntax highlighting
- **Navigation**: Automatic relative link conversion
- **Repository Integration**: GitHub metadata and download buttons

### Documentation Pages
All existing documentation now includes Jekyll front matter for proper rendering:
- Consistent layout across all pages
- Automatic title extraction
- Proper navigation structure

## How to Enable GitHub Pages

After merging this PR, enable GitHub Pages in repository settings:

1. Go to Settings → Pages
2. Set Source to "Deploy from a branch"
3. Select branch: `main`, folder: `/docs`
4. Click Save

The site will be available at: `https://williajm.github.io/mcp_docker/`

## Preview

The documentation site will include:
- Clean, professional landing page
- Easy navigation between sections
- Syntax-highlighted code examples
- Responsive design for mobile/desktop
- Integrated GitHub repository links

## Test Plan
- [x] Created Jekyll configuration
- [x] Created comprehensive landing page
- [x] Added front matter to all docs
- [x] Verified markdown formatting
- [x] Tested relative links
- [ ] Enable GitHub Pages in repository settings (post-merge)
- [ ] Verify site deployment
- [ ] Test navigation and links

🤖 Generated with [Claude Code](https://claude.com/claude-code)