### PR TITLE
docs: Improve GitHub Pages title from 'Home' to 'MCP Docker Server'

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Home
+title: MCP Docker Server
 ---
 
 # MCP Docker Server Documentation


### PR DESCRIPTION
## Summary
- Changed the frontmatter title in `docs/index.md` from the generic "Home" to the more descriptive "MCP Docker Server"

## Reason
The GitHub Pages site was displaying a large "Home" title which was redundant and less informative than showing the actual project name.

## Changes
- Updated `docs/index.md` frontmatter: `title: Home` → `title: MCP Docker Server`

## Test plan
- [ ] Verify the PR passes CI checks
- [ ] After merge, check that https://williajm.github.io/mcp_docker/ displays "MCP Docker Server" instead of "Home"

🤖 Generated with [Claude Code](https://claude.com/claude-code)