### PR TITLE
ci: Add manual trigger to CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,7 @@ on:
   schedule:
     # Run at 6:00 UTC every Monday
     - cron: '0 6 * * 1'
+  workflow_dispatch:
 
 jobs:
   analyze:


### PR DESCRIPTION
Added `workflow_dispatch` trigger to the CodeQL workflow to allow manual runs via GitHub UI or CLI.

This enables running CodeQL scans on-demand without waiting for scheduled runs or code pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)