### PR TITLE
Fix GitHub Pages 404 by adding Jekyll deployment workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,45 @@
+name: Deploy Jekyll site to Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Fixes the 404 error on https://williajm.github.io/mcp_docker/
- Adds proper GitHub Pages Jekyll deployment workflow

## Problem
The GitHub Pages configuration was set to `build_type: "workflow"` but no workflow existed to build and deploy the Jekyll site from `/docs`. This caused the site to return 404 errors despite successful "deployment" runs.

## Solution
Created `.github/workflows/pages.yml` that:
- Builds Jekyll site from `./docs` directory using `actions/jekyll-build-pages@v1`
- Deploys using official `actions/deploy-pages@v4`
- Runs on push to main and manual triggers
- Uses proper permissions for Pages deployment

## Test plan
- [x] Workflow file created with proper Jekyll build configuration
- [ ] Merge PR and verify workflow runs successfully
- [ ] Confirm https://williajm.github.io/mcp_docker/ loads without 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)