### PR TITLE
docs: Add MyPy, MCP Protocol, and Documentation badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 [![Docker](https://img.shields.io/badge/Docker-Management-2496ED.svg?logo=docker&logoColor=white)](https://www.docker.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg)](https://github.com/astral-sh/ruff)
+[![type-checked: mypy](https://img.shields.io/badge/type--checked-mypy-blue.svg)](https://mypy-lang.org/)
+[![MCP](https://img.shields.io/badge/MCP-1.2.0+-5865F2.svg)](https://modelcontextprotocol.io)
+[![Documentation](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://williajm.github.io/mcp_docker/)
 [![Dependabot](https://img.shields.io/badge/Dependabot-enabled-blue.svg?logo=dependabot)](https://github.com/williajm/mcp_docker/security/dependabot)
 
 A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes Docker functionality to AI assistants like Claude. Manage containers, images, networks, and volumes through a type-safe, documented API with safety controls.


### PR DESCRIPTION
## Summary
- Added MyPy type checking badge to highlight strict type safety
- Added MCP Protocol 1.2.0+ badge to showcase protocol compatibility
- Added GitHub Pages documentation badge linking to project docs at https://williajm.github.io/mcp_docker/

## Test plan
- [x] Verify badges render correctly on GitHub
- [x] Confirm badge links are functional
- [x] Check badge alignment with existing badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)