### PR TITLE
Fix all CodeQL security scanning alerts

### DIFF
--- a/src/mcp_docker/docker_wrapper/__init__.py
+++ b/src/mcp_docker/docker_wrapper/__init__.py
@@ -1,3 +1,5 @@
 """Docker client and operations."""
 
+from mcp_docker.docker_wrapper.client import DockerClientWrapper
+
 __all__ = ["DockerClientWrapper"]

--- a/tests/integration/test_image_operations.py
+++ b/tests/integration/test_image_operations.py
@@ -42,7 +42,7 @@ async def cleanup_test_image(mcp_server: MCPDockerServer, test_image_tag: str):
     try:
         await mcp_server.call_tool("docker_remove_image", {"image": test_image_tag, "force": True})
     except Exception:
-        pass
+        pass  # Ignore cleanup errors - resource may not exist
 
 
 @pytest.mark.integration

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -149,7 +149,7 @@ class TestMCPServerE2E:
                     "docker_remove_container", {"container_id": container_name, "force": True}
                 )
             except Exception:
-                pass
+                pass  # Ignore cleanup errors - container may already be removed
 
     @pytest.mark.asyncio
     async def test_e2e_image_workflow(self, mcp_server: MCPDockerServer) -> None:
@@ -203,7 +203,7 @@ class TestMCPServerE2E:
             try:
                 await mcp_server.call_tool("docker_remove_network", {"network_id": network_name})
             except Exception:
-                pass
+                pass  # Ignore cleanup errors - network may already be removed
 
     @pytest.mark.asyncio
     async def test_e2e_volume_workflow(self, mcp_server: MCPDockerServer) -> None:
@@ -240,7 +240,7 @@ class TestMCPServerE2E:
                     "docker_remove_volume", {"volume_name": volume_name, "force": True}
                 )
             except Exception:
-                pass
+                pass  # Ignore cleanup errors - volume may already be removed
 
     @pytest.mark.asyncio
     async def test_resources_integration(self, mcp_server: MCPDockerServer) -> None:
@@ -295,7 +295,7 @@ class TestMCPServerE2E:
                     "docker_remove_container", {"container_id": container_name, "force": True}
                 )
             except Exception:
-                pass
+                pass  # Ignore cleanup errors - container may already be removed
 
     @pytest.mark.asyncio
     async def test_prompts_integration(self, mcp_server: MCPDockerServer) -> None:

--- a/tests/integration/test_network_operations.py
+++ b/tests/integration/test_network_operations.py
@@ -41,7 +41,7 @@ async def cleanup_test_network(mcp_server: MCPDockerServer, test_network_name: s
     try:
         await mcp_server.call_tool("docker_remove_network", {"network_id": test_network_name})
     except Exception:
-        pass
+        pass  # Ignore cleanup errors - network may not exist
 
 
 @pytest.mark.integration
@@ -223,7 +223,7 @@ class TestNetworkOperations:
             try:
                 await mcp_server.call_tool("docker_remove_network", {"network_id": network_name})
             except Exception:
-                pass
+                pass  # Ignore cleanup errors - network may already be removed
 
     @pytest.mark.asyncio
     async def test_network_error_handling(

--- a/tests/integration/test_volume_operations.py
+++ b/tests/integration/test_volume_operations.py
@@ -43,7 +43,7 @@ async def cleanup_test_volume(mcp_server: MCPDockerServer, test_volume_name: str
             "docker_remove_volume", {"volume_name": test_volume_name, "force": True}
         )
     except Exception:
-        pass
+        pass  # Ignore cleanup errors - volume may not exist
 
 
 @pytest.mark.integration
@@ -149,7 +149,7 @@ class TestVolumeOperations:
                     "docker_remove_volume", {"volume_name": volume_name, "force": True}
                 )
             except Exception:
-                pass
+                pass  # Ignore cleanup errors - volume may already be removed
 
     @pytest.mark.asyncio
     async def test_create_volume_with_labels(
@@ -188,7 +188,7 @@ class TestVolumeOperations:
                     "docker_remove_volume", {"volume_name": volume_name, "force": True}
                 )
             except Exception:
-                pass
+                pass  # Ignore cleanup errors - volume may already be removed
 
     @pytest.mark.asyncio
     async def test_remove_volume_with_force(
@@ -321,4 +321,4 @@ class TestVolumeOperations:
                     "docker_remove_volume", {"volume_name": temp_volume_name, "force": True}
                 )
             except Exception:
-                pass
+                pass  # Ignore cleanup errors - volume may already be removed

--- a/tests/unit/test_base_tool.py
+++ b/tests/unit/test_base_tool.py
@@ -249,5 +249,5 @@ class TestOperationSafety:
 
     def test_enum_comparison(self) -> None:
         """Test enum comparison."""
-        assert OperationSafety.SAFE == OperationSafety.SAFE
         assert OperationSafety.SAFE != OperationSafety.DESTRUCTIVE
+        assert OperationSafety.MODERATE != OperationSafety.SAFE

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -255,9 +255,6 @@ class TestMCPDockerServer:
         server = MCPDockerServer(mock_config)
 
         # Mock a destructive tool
-        class MockInput(BaseModel):
-            container_id: str = Field(description="Container ID")
-
         mock_tool = Mock()
         mock_tool.name = "docker_remove_container"
         mock_tool.run = AsyncMock(side_effect=Exception("Container not found"))
@@ -286,9 +283,6 @@ class TestMCPDockerServer:
         server = MCPDockerServer(mock_config)
 
         # Mock a safe tool
-        class MockInput(BaseModel):
-            pass
-
         mock_tool = Mock()
         mock_tool.name = "docker_list_containers"
         mock_tool.run = AsyncMock(return_value=Mock(model_dump=lambda: {"containers": []}))


### PR DESCRIPTION
## Summary
This PR resolves all 15 remaining CodeQL security scanning alerts found in the codebase.

## Changes Made

### Fixed Alerts
1. **Alert #1** - `py/comparison-of-identical-expressions` in `tests/unit/test_base_tool.py:252`
   - Removed redundant self-comparison test (`SAFE == SAFE`)
   - Replaced with meaningful inequality comparisons

2. **Alert #4** - `py/undefined-export` in `src/mcp_docker/docker_wrapper/__init__.py:3`
   - Added explicit import of `DockerClientWrapper` before including it in `__all__`
   - Fixes export declaration without corresponding import

3. **Alert #20, #21** - `py/unused-local-variable` in `tests/unit/test_server.py`
   - Removed unused `MockInput` class definitions (lines 258-259, 289-290)
   - Classes were declared but never used in the tests

4. **Alerts #8-18** - `py/empty-except` in integration test files
   - Added explanatory comments to all empty except blocks in cleanup code
   - Comments clarify that cleanup errors are intentionally ignored (resources may not exist)
   - Affected files:
     - `tests/integration/test_image_operations.py:45`
     - `tests/integration/test_network_operations.py:44, 226`
     - `tests/integration/test_volume_operations.py:46, 152, 191, 324`
     - `tests/integration/test_mcp_server.py:152, 206, 243, 298`

## Test Plan
- [x] All 322 unit tests pass
- [x] Ruff linter passes with no issues
- [x] MyPy type checker passes with no issues
- [x] Changes maintain existing test behavior

## Impact
- No functional changes to production code
- Improved code quality and maintainability
- Resolves all outstanding security scanning alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)