### PR TITLE
Fix GitHub workflow branch references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main ]
 
 jobs:
   test:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main, dev ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, dev ]
+    branches: [ main ]
   schedule:
     # Run at 6:00 UTC every Monday
     - cron: '0 6 * * 1'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,7 +2,7 @@ name: Dependency Review
 
 on:
   pull_request:
-    branches: [ main, dev ]
+    branches: [ main ]
 
 permissions:
   contents: read

--- a/.github/workflows/license-compliance.yml
+++ b/.github/workflows/license-compliance.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main, dev ]
+    branches: [ main ]
   schedule:
     # Run weekly on Mondays at 9:00 AM UTC
     - cron: '0 9 * * 1'

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,9 +2,9 @@ name: Pre-commit
 
 on:
   pull_request:
-    branches: [ main, dev ]
+    branches: [ main ]
   push:
-    branches: [ main, dev ]
+    branches: [ main ]
 
 jobs:
   pre-commit:


### PR DESCRIPTION
## Summary
- Fixed GitHub Actions failing on main branch with "ref 'refs/heads/dev' not found" errors
- Removed references to non-existent dev/develop branches from all workflow files
- Workflows now only trigger on main branch pushes and pull requests

## Changes
- `.github/workflows/pre-commit.yml`: Removed dev branch references
- `.github/workflows/codeql.yml`: Removed dev branch references  
- `.github/workflows/license-compliance.yml`: Removed dev branch references
- `.github/workflows/ci.yml`: Removed develop branch references
- `.github/workflows/dependency-review.yml`: Removed dev branch references

## Test plan
- [ ] Verify workflows pass on this PR
- [ ] After merge, confirm main branch workflows run successfully without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)