### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2025-10-28
+
+### Breaking Changes
+- **Removed Docker Compose support**: All Docker Compose wrapper, tools, and validation code have been removed
+- **Tool count reduced**: From 48 tools to 36 tools (removed 12 Docker Compose tools)
+- Removed `compose_files/` directory and example compose files
+- Removed `src/mcp_docker/compose_wrapper/` module
+- Removed `src/mcp_docker/tools/compose_tools.py`
+- Removed `src/mcp_docker/utils/compose_validation.py`
+
+### Added
+- **Read-only mode**: New `SAFETY_ALLOW_MODERATE_OPERATIONS` environment variable to enable read-only mode
+  - When set to `false`, blocks all MODERATE operations (create, start, stop, restart, pull, etc.)
+  - Allows only SAFE operations (list, inspect, version, logs, stats)
+- **Comprehensive read-only mode testing**: Added 12 new integration tests covering read-only mode functionality
+- **Enhanced test coverage**: 478 tests passing (up from 467), 95.41% code coverage
+- **Better safety validation**: Improved error messages for blocked operations
+
+### Changed
+- **StartContainerTool safety level**: Fixed to return `MODERATE` instead of `SAFE`
+- **Documentation updates**: All documentation updated to reflect Docker Compose removal
+  - Updated tool counts from 48 to 36
+  - Removed Docker Compose sections from examples
+  - Updated version numbers to 0.2.0
+
+### Removed
+- All Docker Compose functionality and related code (~8,000 lines of code removed)
+- Redundant documentation files:
+  - `SECURITY_IMPLEMENTATION.md` (merged into `SECURITY.md`)
+  - `TESTING_SECURITY.md` (content moved to `DEVELOPMENT.md`)
+  - `VERSION_TRACKING.md` (outdated)
+
+### Fixed
+- Safety level classification for container start operations
+- Documentation consistency across all language versions
+
+## [0.1.0] - 2025-10-24
+
+### Added
+- Initial release with 48 Docker tools
+- Container management (10 tools)
+- Image management (9 tools)
+- Network management (6 tools)
+- Volume management (5 tools)
+- System operations (6 tools)
+- Docker Compose management (12 tools)
+- 3 AI prompts (troubleshoot, optimize, generate_compose)
+- 2 resources (container logs, container stats)
+- Three-tier safety system (SAFE/MODERATE/DESTRUCTIVE)
+- Comprehensive documentation
+- 88%+ test coverage
+- Support for Python 3.11-3.13

--- a/docs/API.md
+++ b/docs/API.md
@@ -5,8 +5,8 @@ title: API Reference
 
 # Docker MCP Server - API Reference
 
-**Version:** 1.0.0
-**Last Updated:** 2025-10-24
+**Version:** 0.2.0
+**Last Updated:** 2025-10-28
 
 ## Table of Contents
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -5,8 +5,8 @@ title: Examples
 
 # Docker MCP Server - Usage Examples
 
-**Version:** 1.0.0
-**Last Updated:** 2025-10-24
+**Version:** 0.2.0
+**Last Updated:** 2025-10-28
 
 ## Table of Contents
 

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -116,7 +116,7 @@ export SAFETY_MAX_CONCURRENT_OPERATIONS=10  # Maximum d'opérations simultanées
 
 # Configuration Serveur
 export MCP_SERVER_NAME="mcp-docker"  # Nom du serveur MCP (par défaut : mcp-docker)
-export MCP_SERVER_VERSION="0.1.0"  # Version du serveur MCP (par défaut : 0.1.0)
+export MCP_SERVER_VERSION="0.2.0"  # Version du serveur MCP (par défaut : 0.2.0)
 export MCP_LOG_LEVEL="INFO"  # Niveau de journalisation : DEBUG, INFO, WARNING, ERROR, CRITICAL (par défaut : INFO)
 export MCP_DOCKER_LOG_PATH="/chemin/vers/mcp_docker.log"  # Chemin du fichier journal (optionnel, par défaut mcp_docker.log dans le répertoire de travail)
 ```

--- a/docs/README.it.md
+++ b/docs/README.it.md
@@ -116,7 +116,7 @@ export SAFETY_MAX_CONCURRENT_OPERATIONS=10  # Massimo operazioni simultanee (pre
 
 # Configurazione Server
 export MCP_SERVER_NAME="mcp-docker"  # Nome server MCP (predefinito: mcp-docker)
-export MCP_SERVER_VERSION="0.1.0"  # Versione server MCP (predefinito: 0.1.0)
+export MCP_SERVER_VERSION="0.2.0"  # Versione server MCP (predefinito: 0.2.0)
 export MCP_LOG_LEVEL="INFO"  # Livello di logging: DEBUG, INFO, WARNING, ERROR, CRITICAL (predefinito: INFO)
 export MCP_DOCKER_LOG_PATH="/percorso/a/mcp_docker.log"  # Percorso file di log (opzionale, predefinito mcp_docker.log nella directory di lavoro)
 ```

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1374,5 +1374,5 @@ Need help? Here's how to get support:
 ---
 
 **Last Updated**: October 2025
-**Version**: 0.1.0
+**Version**: 0.2.0
 **Status**: Alpha

--- a/docs/index.md
+++ b/docs/index.md
@@ -266,7 +266,7 @@ MIT License - see [LICENSE](https://github.com/williajm/mcp_docker/blob/main/LIC
 
 ---
 
-**Version**: 1.0.0
-**Last Updated**: 2025-10-25
+**Version**: 0.2.0
+**Last Updated**: 2025-10-28
 **Python**: 3.11+
 **Docker**: API version 1.41+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-docker"
-version = "0.1.0"
+version = "0.2.0"
 description = "MCP server for Docker control"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/mcp_docker/version.py
+++ b/src/mcp_docker/version.py
@@ -4,8 +4,8 @@ Increment the build number each time the code changes to help identify
 which version is running in Claude Desktop.
 """
 
-__version__ = "0.1.0"
-__build__ = 11  # Added container_name scaling warning
+__version__ = "0.2.0"
+__build__ = 12  # v0.2.0: Removed Docker Compose support, added read-only mode
 
 
 def get_full_version() -> str:


### PR DESCRIPTION
# Release v0.2.0

This PR bumps the version to 0.2.0 and includes the release notes.

## Breaking Changes
- **Removed Docker Compose support**: Tool count reduced from 48 to 36 tools
- Removed all Docker Compose related code and documentation

## New Features
- **Read-only mode**: New `SAFETY_ALLOW_MODERATE_OPERATIONS` environment variable
  - Enables strict read-only mode that blocks all MODERATE operations
  - Only allows SAFE operations (list, inspect, version, logs, stats)
- **Enhanced testing**: 12 new integration tests for read-only mode
- **Improved coverage**: 478 tests passing, 95.41% code coverage

## Changes
- Updated all version numbers to 0.2.0
- Created comprehensive CHANGELOG.md
- Updated documentation dates
- Fixed StartContainerTool safety level to MODERATE

## Files Changed
- `pyproject.toml` - Version bump
- `src/mcp_docker/version.py` - Version and build number update
- All documentation files - Version and date updates
- `CHANGELOG.md` - New file with release notes

See CHANGELOG.md for complete details.