### PR TITLE
fix: Correct gh attestation download command syntax

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
             echo "Downloading attestation for $filename..."
             gh attestation download "$file" \
               --owner williajm \
-              --output "attestations/${filename}.intoto.jsonl" || echo "Failed to download attestation for $filename"
+              > "attestations/${filename}.intoto.jsonl" || echo "Failed to download attestation for $filename"
           fi
         done
 


### PR DESCRIPTION
## Fix

The `gh attestation download` command doesn't support an `--output` flag. It writes to stdout by default, so we need to redirect the output instead.

## Problem

The release workflow for v0.4.1 failed to upload attestation bundles because it was using an invalid `--output` flag:

```bash
gh attestation download "$file" --owner williajm --output "attestations/${filename}.intoto.jsonl"
# Error: unknown flag: --output
```

## Solution

Redirect stdout to the output file:

```bash
gh attestation download "$file" --owner williajm > "attestations/${filename}.intoto.jsonl"
```

## Impact

This fix enables:
- ✅ Attestation bundles uploaded as `.intoto.jsonl` files to releases
- ✅ Offline verification of release artifacts
- ✅ OpenSSF Scorecard Signed-Releases check passing (0 → 10)

## Testing

After merge, we can manually trigger the workflow for v0.4.1 to add the missing attestation bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>