### PR TITLE
fix: Change Welsh documentation badge color to blue for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 [![type-checked: mypy](https://img.shields.io/badge/type--checked-mypy-blue.svg)](https://mypy-lang.org/)
 [![MCP](https://img.shields.io/badge/MCP-1.2.0+-5865F2.svg)](https://modelcontextprotocol.io)
 [![Documentation](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://williajm.github.io/mcp_docker/)
-[![Dogfennaeth Cymraeg](https://img.shields.io/badge/docs-Cymraeg-red)](https://williajm.github.io/mcp_docker/README.cy)
+[![Dogfennaeth Cymraeg](https://img.shields.io/badge/docs-Cymraeg-blue)](https://williajm.github.io/mcp_docker/README.cy)
 [![Documentation en Français](https://img.shields.io/badge/docs-Fran%C3%A7ais-blue)](https://williajm.github.io/mcp_docker/README.fr)
 [![Dokumentation auf Deutsch](https://img.shields.io/badge/docs-Deutsch-blue)](https://williajm.github.io/mcp_docker/README.de)
 [![Documentazione in Italiano](https://img.shields.io/badge/docs-Italiano-blue)](https://williajm.github.io/mcp_docker/README.it)


### PR DESCRIPTION
## Summary

- Fixed Welsh (Cymraeg) documentation badge color from red to blue
- Ensures visual consistency across all language documentation badges
- All language badges now use the same blue color scheme

## Test plan

- [x] Verify README.md badge color change (line 24)
- [x] Confirm all language documentation badges now use blue color
- [x] Check that badge still links to correct Welsh documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)