### PR TITLE
Add CODEOWNERS file to require owner approval

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# CODEOWNERS
+#
+# This file defines code ownership for the repository.
+# All changes require approval from the owner.
+#
+# Documentation: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for all files - everything requires your approval
+* @williajm


### PR DESCRIPTION
## Summary

Adds a CODEOWNERS file that requires repository owner approval for all changes, strengthening protection against unauthorized modifications.

## Changes

- Created `.github/CODEOWNERS` with wildcard rule requiring @williajm approval for all files

## Benefits

- **External Contribution Protection**: All external PRs must be explicitly approved by the repository owner
- **Dependabot Safety**: Prevents auto-merge of dependency updates without owner review
- **Enforces Code Owner Review**: Works with existing ruleset's `require_code_owner_review: true` setting
- **Clear Ownership**: Documents repository ownership for contributors

## How It Works

With the existing branch protection ruleset:
- 2 total reviews required
- 1 review must be from code owner (@williajm)
- No PR can merge without owner approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)