### PR TITLE
Enable automatic GitHub issue creation for fuzzing crashes

### DIFF
--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -16,4 +16,4 @@ fuzzing_engines:
   - libfuzzer
 
 # File types to preserve for coverage
-file_github_issue_for_crashes: false
+file_github_issue_for_crashes: true


### PR DESCRIPTION
## Summary

Enables automatic GitHub issue creation when ClusterFuzzLite discovers crashes during fuzzing runs, ensuring findings are tracked and actionable.

## Changes

- Changed `file_github_issue_for_crashes: false` → `true` in `.clusterfuzzlite/project.yaml`

## Problem Solved

**Before**: Fuzzing results were ephemeral
- 1-hour batch fuzzing runs on main branch → results lost after workflow completes
- Weekly deep fuzzing → no visibility into findings
- Manual checking required to see if crashes occurred

**After**: Automatic issue tracking
- Crashes found in batch fuzzing → GitHub issue created automatically
- Weekly fuzzing findings → Tracked as issues
- Stack traces and reproducer details included in issues
- Notifications when crashes are discovered

## How It Works

When ClusterFuzzLite finds a crash in any mode (PR, batch, or scheduled):
1. Creates a GitHub issue with crash details
2. Includes sanitizer output, stack trace, crash type
3. Links back to the workflow run for debugging
4. Issue remains open until fixed

## Impact

- ✅ No lost fuzzing results
- ✅ Automated crash tracking
- ✅ Better security posture through visibility
- ✅ No spam - only creates issues when actual crashes occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)