### PR TITLE
fix: Add artifact upload for PyPI publishing job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,13 @@ jobs:
         echo "Attestation bundles downloaded:"
         ls -lh attestations/
 
+    - name: Upload package artifacts for PyPI job
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+      with:
+        name: dist-packages
+        path: dist/
+        retention-days: 1
+
     - name: Upload Release Assets
       env:
         GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Problem

The v1.0.0 release workflow failed during PyPI publishing:
```
Error: Unable to download artifact(s): Artifact not found for name: dist-packages
```

## Root Cause

The `build-and-sign` job builds packages but doesn't create a workflow artifact. The `publish-pypi` job (which runs after) tries to download `dist-packages` artifact that was never uploaded.

## Fix

Added `upload-artifact` step after building packages:
```yaml
- name: Upload package artifacts for PyPI job
  uses: actions/upload-artifact@v5.0.0
  with:
    name: dist-packages
    path: dist/
    retention-days: 1
```

## Testing

After merge, will need to:
1. Delete v1.0.0 release and tag
2. Recreate v1.0.0 release
3. Workflow will run with fix and publish to PyPI

## Impact

Critical hotfix - blocks v1.0.0 PyPI release.