### PR TITLE
fix: Update pypa/gh-action-pypi-publish to v1.13.0 for Metadata 2.4 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,6 +157,6 @@ jobs:
         path: dist/
 
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@f7600683efdcb7656dec5b29656edb7bc586e597 # v1.12.2
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
       with:
         attestations: true


### PR DESCRIPTION
## Problem

The v1.0.0 release fails during PyPI publishing with:
```
ERROR InvalidDistribution: Metadata is missing required fields: Name, Version.
```

## Root Cause

The action version v1.12.2 (from November 2023) bundles an **older Twine/pkginfo stack** that doesn't understand **Core Metadata 2.4**.

Our wheel is correctly built and contains:
```
Metadata-Version: 2.4
Name: mcp-docker
Version: 1.0.0
```

However, when the old action parses metadata v2.4, it reports all fields as "missing" because it doesn't recognize the format.

## Solution

Update to **v1.13.0** (September 2024) which includes updated Twine/pkginfo that properly supports metadata v2.4.

**Change:**
```diff
- uses: pypa/gh-action-pypi-publish@f7600683... # v1.12.2
+ uses: pypa/gh-action-pypi-publish@ed0c5393... # v1.13.0
```

Still pinned to commit SHA for security.

## After Merge

Will need to recreate v1.0.0 release again to trigger the fixed workflow.

## Credit

Issue diagnosed by ChatGPT analysis of the build logs.