### PR TITLE
fix: Pin pre-commit package version in CI workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -34,7 +34,7 @@ jobs:
           pre-commit-${{ runner.os }}-
 
     - name: Install pre-commit
-      run: pip install pre-commit
+      run: pip install pre-commit==4.0.1
 
     - name: Run pre-commit
       run: pre-commit run --all-files --show-diff-on-failure --color=always


### PR DESCRIPTION
## Summary

- Pins `pre-commit` package to version 4.0.1 in `.github/workflows/pre-commit.yml`
- Addresses security score 9 issue: unpinned pip command at line 38
- Ensures supply chain security, reproducible builds, and consistent CI behavior

## Test plan

- [ ] Verify CI workflow runs successfully with pinned version
- [ ] Confirm pre-commit hooks execute correctly
- [ ] Check that workflow behavior remains unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)