### PR TITLE
Fix workflow concurrency conflict between docs and pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,9 +17,9 @@ on:
 permissions:
   contents: read
 
-# Allow one concurrent deployment
+# Allow one concurrent documentation check (separate from Pages deployment)
 concurrency:
-  group: "pages"
+  group: "docs-check-${{ github.ref }}"
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Problem

The Documentation workflow and Jekyll Pages deployment workflow were using the same concurrency group (`"pages"`), causing conflicts when both triggered simultaneously on pushes to main.

Symptoms:
- "Deploy Jekyll site to Pages" frequently canceled with: _"This workflow is waiting for Documentation to complete before running"_
- One workflow would block the other, preventing successful deployments

## Root Cause

Both workflows defined:
```yaml
concurrency:
  group: "pages"
```

This meant only one could run at a time, and `docs.yml` had `cancel-in-progress: true`, causing it to cancel itself when pages deployment was already running.

## Solution

Changed `docs.yml` concurrency group from `"pages"` to `"docs-check-${{ github.ref }}"`.

This allows:
- ✅ Documentation checks to run independently of Pages deployments
- ✅ Both workflows to execute in parallel without conflicts
- ✅ Per-branch concurrency control for doc checks (cancels old runs on new pushes to same branch)

## Testing

After merging, both workflows should run successfully when triggered together on main branch pushes.

## Changes

- `.github/workflows/docs.yml`: Updated concurrency group to `"docs-check-${{ github.ref }}"`
