### PR TITLE
fix: Sync uv.lock with pyproject.toml version 1.0.3

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -565,7 +565,7 @@ wheels = [
 
 [[package]]
 name = "mcp-docker"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
## Summary
- Syncs `uv.lock` with `pyproject.toml` version 1.0.3
- Resolves version mismatch introduced in PR #96
- Maintains consistency with release pattern from v1.0.2 and v1.0.1

## Context
After PR #96 bumped the version to 1.0.3 in `pyproject.toml`, the `uv.lock` file wasn't regenerated, leaving it at version 1.0.2. This creates an inconsistency similar to the v1.0.0 release where the lock file wasn't properly synced.

## Changes
- Updates `uv.lock` to reflect version 1.0.3

## Test Plan
- [x] Verify lock file version matches pyproject.toml
- [x] Confirm only version number changed in lock file
- [x] Check git history shows proper sync pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)