### PR TITLE
fix: Allow stdio transport to bypass IP allowlist

### DIFF
--- a/src/mcp_docker/auth/middleware.py
+++ b/src/mcp_docker/auth/middleware.py
@@ -50,9 +50,12 @@ class AuthMiddleware:
         Raises:
             AuthenticationError: If IP is not allowed
         """
-        # Check IP allowlist if configured
-        if self.config.allowed_client_ips and (
-            not ip_address or ip_address not in self.config.allowed_client_ips
+        # Check IP allowlist if configured (only for network transports)
+        # stdio transport (ip_address=None) bypasses the allowlist
+        if (
+            self.config.allowed_client_ips
+            and ip_address
+            and ip_address not in self.config.allowed_client_ips
         ):
             logger.warning(f"Request blocked: IP {ip_address} not in allowlist")
             raise AuthenticationError(f"IP address not allowed: {ip_address}")
@@ -73,12 +76,13 @@ class AuthMiddleware:
             ip_address: IP address to check
 
         Returns:
-            True if IP is allowed or no allowlist is configured
+            True if IP is allowed, no allowlist is configured, or ip_address is None (stdio)
         """
         if not self.config.allowed_client_ips:
             return True
 
+        # stdio transport (ip_address=None) bypasses the allowlist
         if not ip_address:
-            return False
+            return True
 
         return ip_address in self.config.allowed_client_ips

--- a/tests/unit/test_auth_middleware.py
+++ b/tests/unit/test_auth_middleware.py
@@ -1,0 +1,134 @@
+"""Unit tests for authentication middleware."""
+
+import pytest
+
+from mcp_docker.auth.middleware import AuthenticationError, AuthMiddleware
+from mcp_docker.config import SecurityConfig
+
+
+class TestAuthMiddleware:
+    """Test authentication middleware functionality."""
+
+    def test_no_allowlist_allows_all_ips(self) -> None:
+        """Test that no allowlist allows all IP addresses."""
+        config = SecurityConfig(allowed_client_ips=[])
+        middleware = AuthMiddleware(config)
+
+        # Should allow any IP
+        result = middleware.authenticate_request(ip_address="192.168.1.1")
+        assert result.client_id == "192.168.1.1"
+        assert result.ip_address == "192.168.1.1"
+
+        result = middleware.authenticate_request(ip_address="10.0.0.1")
+        assert result.client_id == "10.0.0.1"
+
+    def test_no_allowlist_allows_none_ip(self) -> None:
+        """Test that no allowlist allows None IP (stdio transport)."""
+        config = SecurityConfig(allowed_client_ips=[])
+        middleware = AuthMiddleware(config)
+
+        # Should allow None (stdio)
+        result = middleware.authenticate_request(ip_address=None)
+        assert result.client_id == "unknown"
+        assert result.ip_address is None
+
+    def test_allowlist_blocks_unlisted_ips(self) -> None:
+        """Test that allowlist blocks IP addresses not in the list."""
+        config = SecurityConfig(allowed_client_ips=["192.168.1.100", "10.0.0.50"])
+        middleware = AuthMiddleware(config)
+
+        # Should block unlisted IP
+        with pytest.raises(AuthenticationError) as exc_info:
+            middleware.authenticate_request(ip_address="192.168.1.200")
+
+        assert "IP address not allowed" in str(exc_info.value)
+        assert "192.168.1.200" in str(exc_info.value)
+
+    def test_allowlist_allows_listed_ips(self) -> None:
+        """Test that allowlist allows IP addresses in the list."""
+        config = SecurityConfig(allowed_client_ips=["192.168.1.100", "10.0.0.50"])
+        middleware = AuthMiddleware(config)
+
+        # Should allow listed IPs
+        result = middleware.authenticate_request(ip_address="192.168.1.100")
+        assert result.client_id == "192.168.1.100"
+        assert result.ip_address == "192.168.1.100"
+
+        result = middleware.authenticate_request(ip_address="10.0.0.50")
+        assert result.client_id == "10.0.0.50"
+
+    def test_allowlist_allows_none_ip_stdio(self) -> None:
+        """Test that allowlist allows None IP (stdio transport) - critical for stdio+SSE config.
+
+        This test validates the fix for the regression where stdio transport was blocked
+        when SECURITY_ALLOWED_CLIENT_IPS was configured for SSE deployment security.
+        stdio should always bypass IP allowlist since it's local trusted process model.
+        """
+        config = SecurityConfig(allowed_client_ips=["192.168.1.100"])
+        middleware = AuthMiddleware(config)
+
+        # Should allow None (stdio) even when allowlist is configured
+        # This is the critical fix - stdio must work alongside SSE security
+        result = middleware.authenticate_request(ip_address=None)
+        assert result.client_id == "unknown"
+        assert result.ip_address is None
+        assert result.description == "IP-based access"
+
+    def test_check_ip_allowed_no_allowlist(self) -> None:
+        """Test check_ip_allowed with no allowlist."""
+        config = SecurityConfig(allowed_client_ips=[])
+        middleware = AuthMiddleware(config)
+
+        assert middleware.check_ip_allowed("192.168.1.1") is True
+        assert middleware.check_ip_allowed("10.0.0.1") is True
+        assert middleware.check_ip_allowed(None) is True
+
+    def test_check_ip_allowed_with_allowlist(self) -> None:
+        """Test check_ip_allowed with allowlist configured."""
+        config = SecurityConfig(allowed_client_ips=["192.168.1.100", "10.0.0.50"])
+        middleware = AuthMiddleware(config)
+
+        # Listed IPs should be allowed
+        assert middleware.check_ip_allowed("192.168.1.100") is True
+        assert middleware.check_ip_allowed("10.0.0.50") is True
+
+        # Unlisted IPs should be blocked
+        assert middleware.check_ip_allowed("192.168.1.200") is False
+        assert middleware.check_ip_allowed("10.0.0.100") is False
+
+        # None (stdio) should be allowed
+        assert middleware.check_ip_allowed(None) is True
+
+    def test_client_info_structure(self) -> None:
+        """Test that ClientInfo is properly constructed."""
+        config = SecurityConfig(allowed_client_ips=["192.168.1.100"])
+        middleware = AuthMiddleware(config)
+
+        # Test with IP address
+        result = middleware.authenticate_request(ip_address="192.168.1.100")
+        assert result.client_id == "192.168.1.100"
+        assert result.api_key_hash == "none"
+        assert result.description == "IP-based access"
+        assert result.ip_address == "192.168.1.100"
+
+        # Test with None (stdio)
+        result = middleware.authenticate_request(ip_address=None)
+        assert result.client_id == "unknown"
+        assert result.api_key_hash == "none"
+        assert result.description == "IP-based access"
+        assert result.ip_address is None
+
+    def test_edge_cases(self) -> None:
+        """Test edge cases for IP allowlist."""
+        # Empty allowlist (all allowed)
+        config = SecurityConfig(allowed_client_ips=[])
+        middleware = AuthMiddleware(config)
+        assert middleware.check_ip_allowed("") is True
+        assert middleware.check_ip_allowed("0.0.0.0") is True
+
+        # Single IP in allowlist
+        config = SecurityConfig(allowed_client_ips=["127.0.0.1"])
+        middleware = AuthMiddleware(config)
+        assert middleware.check_ip_allowed("127.0.0.1") is True
+        assert middleware.check_ip_allowed("127.0.0.2") is False
+        assert middleware.check_ip_allowed(None) is True  # stdio always allowed


### PR DESCRIPTION
## Summary
Fixes critical regression from #102 where stdio transport was blocked when `SECURITY_ALLOWED_CLIENT_IPS` was configured.

## Problem
After removing SSH auth in #102, `AuthMiddleware.authenticate_request()` always enforces the IP allowlist. stdio transport never has an IP address (`ip_address=None`), so when `SECURITY_ALLOWED_CLIENT_IPS` is configured, all stdio tool calls fail with `AuthenticationError`. This breaks the default Claude/Desktop workflow whenever an IP allowlist is set for SSE security.

## Solution
- stdio transport (`ip_address=None`) now bypasses the IP allowlist since it uses the local trusted process model
- Updated both `authenticate_request()` and `check_ip_allowed()` methods for consistency
- Added comprehensive unit tests (9 new tests) to prevent future regressions

## Changes
- `src/mcp_docker/auth/middleware.py`: Allow None IP addresses (stdio) to bypass allowlist
- `tests/unit/test_auth_middleware.py`: New comprehensive test suite for middleware

## Test Plan
- ✅ All 631 unit tests pass
- ✅ All 83 integration tests pass  
- ✅ New tests specifically validate stdio bypass behavior
- ✅ Ruff linting passes
- ✅ mypy type checking passes

## Impact
This ensures users can run stdio (Claude/Desktop) while securing SSE deployments with IP allowlists, matching the promise in SECURITY.md that IP filtering is "only effective for SSE transport."

Fixes #102 regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)