### PR TITLE
fix: Add github_token to Claude workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,6 +40,7 @@ jobs:
         uses: anthropics/claude-code-action@8a1c4371755898f67cd97006ba7c97702d5fc4bf # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -45,6 +45,7 @@ jobs:
         uses: anthropics/claude-code-action@8a1c4371755898f67cd97006ba7c97702d5fc4bf # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary
Fix Claude workflows by adding the required `github_token` parameter.

## Problem
The Claude code workflows were failing with "Invalid OIDC token" error because they were missing the `github_token` parameter.

## Solution
The `claude-code-action` requires **two** tokens:
1. `claude_code_oauth_token` - for Claude API authentication ✓
2. `github_token` - for GitHub API operations (commenting, etc.) ❌ (was missing)

## Changes
- Added `github_token: ${{ secrets.GITHUB_TOKEN }}` to both workflows:
  - `.github/workflows/claude-code-review.yml`
  - `.github/workflows/claude.yml`

## Testing
Once merged, PR #108 will use these fixed workflows from main and should work correctly.

## Priority
**High** - Blocks PR #108 from having working Claude workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)