### PR TITLE
chore: Bump version to 1.1.1.dev0 for next development cycle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-docker"
-version = "1.1.0"
+version = "1.1.1.dev0"
 description = "Model Context Protocol server for Docker management with AI assistants"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
Bump version to 1.1.1.dev0 following PEP 440 versioning workflow after v1.1.0 release.

## Changes
- Update `pyproject.toml`: `version = "1.1.1.dev0"`

## Rationale
According to our versioning workflow (CLAUDE.md):
- After releasing v1.1.0, immediately bump to next dev version
- `.dev0` suffix indicates this is in-progress work toward the next release
- Development versions are not published to PyPI
- Makes it clear the code is not a released version

## References
- Release v1.1.0: https://github.com/williajm/mcp_docker/releases/tag/v1.1.0
- PEP 440: https://peps.python.org/pep-0440/