### PR TITLE
chore: Bump version to 1.1.2.dev0 for next development cycle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-docker"
-version = "1.1.1"
+version = "1.1.2.dev0"
 description = "Model Context Protocol server for Docker management with AI assistants"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Post-release version bump following PEP 440 versioning.

After releasing v1.1.1, bump version to 1.1.2.dev0 to indicate:
- This is development work toward the next release
- Not a released version (the .dev0 suffix)
- Git builds and local installs will show the dev version

See CLAUDE.md for versioning workflow details.