### PR TITLE
fix: Update Docker tool count from 33 to 36 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that ex
 
 ## Features
 
-- **33 Docker Tools**: Individually optional via config. Complete container, image, network, volume, and system management
+- **36 Docker Tools**: Individually optional via config. Complete container, image, network, volume, and system management
 - **5 AI Prompts**: Intelligent troubleshooting, optimization, networking debug, and security analysis
 - **2 Resources**: Real-time container logs and resource statistics
 - **2 Transport Options**: stdio (local) and HTTP (network deployments)


### PR DESCRIPTION
## Summary
Fixes incorrect Docker tool count in README badges section.

## Changes
- Updated "33 Docker Tools" to "36 Docker Tools" in README.md line 20

## Why
The README incorrectly stated 33 Docker tools, but the actual count is 36:
- CLAUDE.md states: "36 Docker tools"
- docs/index.md states: "36 Docker Tools"
- This discrepancy was confusing

## Verification
✅ Matches CLAUDE.md
✅ Matches docs/index.md
✅ All pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)