### PR TITLE
docs: Update tool count from 36 to 33 in CLAUDE.md and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is an MCP (Model Context Protocol) server that exposes Docker functionality to AI assistants. It provides 36 Docker tools, 5 AI prompts, and 2 resources for managing containers, images, networks, and volumes with comprehensive safety controls.
+This is an MCP (Model Context Protocol) server that exposes Docker functionality to AI assistants. It provides 33 Docker tools, 5 AI prompts, and 2 resources for managing containers, images, networks, and volumes with comprehensive safety controls.
 
 **Key Technologies:**
 - Python 3.11+ with strict type checking (mypy)

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that ex
 
 ## Features
 
-- **36 Docker Tools**: Complete container, image, network, volume, and system management
+- **33 Docker Tools**: Complete container, image, network, volume, and system management
 - **5 AI Prompts**: Intelligent troubleshooting, optimization, networking debug, and security analysis
 - **2 Resources**: Real-time container logs and resource statistics
 - **Type Safety**: Full type hints with Pydantic validation and mypy strict mode
@@ -64,7 +64,7 @@ See [README.md](https://github.com/williajm/mcp_docker/blob/main/README.md#safet
 
 ## What's Available
 
-- **36 Docker Tools** - Container, image, network, volume, and system management
+- **33 Docker Tools** - Container, image, network, volume, and system management
 - **5 AI Prompts** - Troubleshooting, optimization, networking debug, security audit, compose generation
 - **2 Resources** - Container logs and stats streaming
 


### PR DESCRIPTION
## Summary
Corrects outdated tool count in CLAUDE.md and docs/index.md to match the actual count of 33 tools.

## Changes
- **CLAUDE.md**: 36 → 33 tools
- **docs/index.md**: 36 → 33 tools (2 occurrences)

## Why
The tool count was reduced from 36 to 33 in PR #122 when system tools were consolidated:
- Removed: `docker_system_info`, `docker_system_df`, `docker_healthcheck` 
- Kept: `docker_version`, `docker_events`, `docker_prune_system`

**Current breakdown:**
- Container Management: 10 tools
- Image Management: 9 tools
- Network Management: 6 tools
- Volume Management: 5 tools
- System Tools: 3 tools
- **Total: 33 tools**

README.md was already correct at 33 tools.

## Verification
✅ Matches README.md tool count
✅ Matches actual implementation (grep shows 33 tools)
✅ All pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)