### PR TITLE
chore: Bump version to 1.2.1.dev0 for next development cycle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-docker"
-version = "1.2.0"
+version = "1.2.1.dev0"
 description = "Model Context Protocol server for Docker management with AI assistants"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
Bumps version to `1.2.1.dev0` following v1.2.0 release.

## Changes
- `pyproject.toml`: `1.2.0` → `1.2.1.dev0`

## Why
Per [PEP 440](https://peps.python.org/pep-0440/) and project versioning guidelines in CLAUDE.md:
- After releasing `1.2.0`, immediately bump to next dev version
- The `.dev0` suffix indicates in-progress work toward next release
- Prevents confusion between released `1.2.0` and in-progress `1.2.1`

## Workflow
1. **Release** (e.g., `1.2.0`) - published to PyPI
2. **Immediately bump** to `1.2.1.dev0` (this PR)
3. **Development** - all commits use `1.2.1.dev0`
4. **Next release** - remove `.dev0` suffix when ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)