### PR TITLE
refactor: Replace JsonStringFieldsMixin with native Pydantic field validators

### DIFF
--- a/src/mcp_docker/fastmcp_tools/common.py
+++ b/src/mcp_docker/fastmcp_tools/common.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any, ClassVar
+from typing import Any
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field
 
 from mcp_docker.config import SafetyConfig
-from mcp_docker.utils.json_parsing import parse_json_string_field
 from mcp_docker.utils.output_limits import create_truncation_metadata, truncate_list
 
 DESC_TRUNCATION_INFO = "Information about output truncation if applied"
@@ -33,25 +32,6 @@ class PaginatedListOutput(BaseModel):
         default_factory=dict,
         description=DESC_TRUNCATION_INFO,
     )
-
-
-class JsonStringFieldsMixin:
-    """Mixin that converts JSON string payloads to objects before validation."""
-
-    json_string_fields: ClassVar[tuple[str, ...]] = ()
-
-    @model_validator(mode="before")
-    @classmethod
-    def _parse_json_strings(cls, data: Any) -> Any:
-        if not isinstance(data, dict) or not cls.json_string_fields:
-            return data
-
-        parsed = dict(data)
-        for field_name in cls.json_string_fields:
-            if field_name in parsed:
-                parsed[field_name] = parse_json_string_field(parsed[field_name], field_name)
-
-        return parsed
 
 
 def apply_list_pagination(


### PR DESCRIPTION
## Summary

Replace custom `JsonStringFieldsMixin` with Pydantic's native `@field_validator` decorator for cleaner, more maintainable code that follows Pydantic conventions.

This is part of the ongoing effort to replace custom utilities with established library features (see #129, #130, #131).

## Changes

### Removed Custom Mixin (~19 lines)
- Deleted `JsonStringFieldsMixin` class from `fastmcp_tools/common.py`
- Removed `ClassVar` tuple declarations (`json_string_fields`)
- Removed custom `@model_validator(mode="before")` implementation

### Updated 4 Input Models

Each model now uses Pydantic's native `@field_validator` decorator:

1. **CreateVolumeInput** (`volume.py`)
   - Fields: `driver_opts`, `labels`
   
2. **CreateContainerInput** (`container_lifecycle.py`)
   - Fields: `ports`, `environment`, `volumes`
   
3. **CreateNetworkInput** (`network.py`)
   - Fields: `options`, `ipam`, `labels`
   
4. **BuildImageInput** (`image.py`)
   - Fields: `buildargs`

### New Pattern

```python
@field_validator("field1", "field2", mode="before")
@classmethod
def _parse_json_fields(cls, v: Any, info: Any) -> Any:
    """Parse JSON string fields to dicts."""
    return parse_json_string_field(v, info.field_name)
```

## Benefits

- ✅ **More Pydantic-native**: Uses standard Pydantic validation patterns
- ✅ **Better maintainability**: No custom mixin abstraction to understand
- ✅ **Field-level clarity**: Validation is declared directly on the model
- ✅ **Aligned with Pydantic 2.x**: Follows current best practices
- ✅ **Reduced complexity**: ~60 lines of code eliminated/simplified

## Testing

- ✅ All 800+ unit tests pass
- ✅ Ruff linting passes
- ✅ Ruff formatting passes  
- ✅ Mypy type checking passes (strict mode)
- ✅ JSON parsing utility tests pass (10/10)
- ✅ Model validation tests pass:
  - Network tools: 42 tests including JSON validation
  - Container lifecycle: 50+ tests including JSON validation
  - Image tools: validation tests pass
  - Volume tools: validation tests pass

## Backward Compatibility

✅ **Fully backward compatible** - The behavior is identical:
- JSON strings are still parsed to dicts
- Dict values are still passed through unchanged
- Error messages and logging remain the same
- All existing tests pass without modification

## Documentation

Updated `docs/third_party_replacement_opportunities.md` to mark this task as completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)