### PR TITLE
chore: Bump version to 1.2.2.dev0 for next development cycle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-docker"
-version = "1.2.1"
+version = "1.2.2.dev0"
 description = "Model Context Protocol server for Docker management with AI assistants"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Version Bump to 1.2.2.dev0

Following the release of v1.2.1, this PR bumps the version to `1.2.2.dev0` to indicate ongoing development toward the next release.

### Changes
- Updated `pyproject.toml` version from `1.2.1` → `1.2.2.dev0`

### Context
According to our [versioning workflow](CLAUDE.md#versioning):
- After releasing (e.g., `1.2.1`), immediately bump to next dev version
- The `.dev0` suffix indicates this is not a released version
- Prevents confusion between released `1.2.1` and in-progress `1.2.2`
- Follows standard Python packaging conventions (PEP 440)

🤖 Generated with [Claude Code](https://claude.com/claude-code)