### PR TITLE
refactor: Parameterize tests and clean up documentation (-1,378 lines)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -183,7 +183,7 @@ Some variables accept JSON arrays:
 ```bash
 # Correct formats
 SECURITY_ALLOWED_CLIENT_IPS='["127.0.0.1", "192.168.1.100"]'
-CORS_ALLOW_ORIGINS='["https://app1.com", "https://app2.com"]'
+CORS_ALLOWED_ORIGINS='["https://app1.com", "https://app2.com"]'
 HTTPSTREAM_ALLOWED_HOSTS='["api.example.com", "10.0.1.50"]'
 ```
 

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ SAFETY_ALLOW_DESTRUCTIVE_OPERATIONS=true
 | **Audit Logging** | Manual setup | ✅ Built-in |
 | **Rate Limiting** | ❌ None | ✅ Configurable |
 | **Input Validation** | ❌ None | ✅ Pydantic schemas |
-| **Docker Coverage** | 100% (all features) | 36 core operations |
+| **Docker Coverage** | 100% (all features) | 33 core operations |
 | **Complexity** | Low (standard commands) | Medium (MCP protocol) |
 
 **When to use MCP Server:**
@@ -369,8 +369,8 @@ uv run pytest tests/integration/ -v -m integration
 # Run E2E tests (requires Docker, comprehensive)
 uv run pytest tests/e2e/ -v -m e2e
 
-# Run E2E tests excluding slow tests
-uv run pytest tests/e2e/ -v -m "e2e and not slow"
+# Run E2E tests excluding stress tests
+uv run pytest tests/e2e/ -v -m "e2e and not stress"
 
 # Run fuzz tests locally (requires atheris)
 python3 tests/fuzz/fuzz_validation.py -atheris_runs=10000
@@ -386,14 +386,16 @@ The project uses [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/) fo
 mcp_docker/
 ├── src/
 │   └── mcp_docker/
-│       ├── __main__.py          # Entry point
-│       ├── server.py            # MCP server implementation
+│       ├── __main__.py          # Entry point (transport selection)
+│       ├── fastmcp_server.py    # MCP server implementation
 │       ├── config.py            # Configuration management
-│       ├── docker/              # Docker SDK wrapper
-│       ├── tools/               # MCP tool implementations
-│       ├── resources/           # MCP resource providers
-│       ├── prompts/             # MCP prompt templates
-│       └── utils/               # Utilities (logging, validation, safety)
+│       ├── docker_wrapper/      # Docker SDK wrapper
+│       ├── fastmcp_tools/       # MCP tool implementations
+│       ├── fastmcp_resources.py # MCP resource providers
+│       ├── fastmcp_prompts.py   # MCP prompt templates
+│       ├── middleware/          # Auth, safety, rate limiting
+│       ├── security/            # Audit logging, rate limiter
+│       └── utils/               # Validation, safety, errors
 ├── tests/                       # Test suite
 ├── docs/                        # Documentation
 └── pyproject.toml              # Project configuration

--- a/docs/index.md
+++ b/docs/index.md
@@ -128,7 +128,7 @@ MIT License - see [LICENSE](https://github.com/williajm/mcp_docker/blob/main/LIC
 
 ---
 
-**Version**: 1.2.1
-**Last Updated**: 2025-11-20
+**Version**: 1.2.2.dev0
+**Last Updated**: 2025-11-25
 **Python**: 3.11+
 **Docker**: API version 1.41+

--- a/src/mcp_docker/config.py
+++ b/src/mcp_docker/config.py
@@ -177,10 +177,6 @@ class SafetyConfig(BaseSettings):
         default=False,
         description="Allow creating privileged containers",
     )
-    require_confirmation_for_destructive: bool = Field(
-        default=True,
-        description="Require explicit confirmation for destructive operations",
-    )
     max_concurrent_operations: int = Field(
         default=10,
         description="Maximum number of concurrent Docker operations",
@@ -206,16 +202,6 @@ class SafetyConfig(BaseSettings):
         description="Maximum number of items to return from list operations (0 = unlimited)",
         ge=0,
         le=10000,
-    )
-    truncate_inspect_output: bool = Field(
-        default=False,
-        description="Truncate large inspect output fields to prevent token limit issues",
-    )
-    max_inspect_field_bytes: int = Field(
-        default=65536,  # 64 KB
-        description="Maximum bytes for individual inspect output fields when truncation enabled",
-        ge=1024,  # 1 KB minimum
-        le=1048576,  # 1 MB maximum
     )
 
     # Tool filtering (works alongside safety level restrictions)

--- a/src/mcp_docker/safety/core.py
+++ b/src/mcp_docker/safety/core.py
@@ -111,18 +111,14 @@ class SafetyEnforcer:
             )
 
         # Check destructive operations
-        if safety_level == OperationSafety.DESTRUCTIVE:
-            if not self.config.allow_destructive_operations:
-                raise UnsafeOperationError(
-                    f"Destructive operation '{tool_name}' is not allowed. "
-                    "Set SAFETY_ALLOW_DESTRUCTIVE_OPERATIONS=true to enable."
-                )
-
-            if self.config.require_confirmation_for_destructive:
-                logger.warning(
-                    f"Destructive operation '{tool_name}' requires confirmation. "
-                    "This would normally prompt for user confirmation."
-                )
+        if (
+            safety_level == OperationSafety.DESTRUCTIVE
+            and not self.config.allow_destructive_operations
+        ):
+            raise UnsafeOperationError(
+                f"Destructive operation '{tool_name}' is not allowed. "
+                "Set SAFETY_ALLOW_DESTRUCTIVE_OPERATIONS=true to enable."
+            )
 
     def check_tool_allowed_and_safe(
         self,

--- a/src/mcp_docker/utils/safety.py
+++ b/src/mcp_docker/utils/safety.py
@@ -5,9 +5,12 @@ from enum import Enum
 from typing import Any
 
 from mcp_docker.utils.errors import UnsafeOperationError, ValidationError
+from mcp_docker.utils.logger import get_logger
 from mcp_docker.utils.validation import (
     sanitize_command as validate_command_structure,
 )
+
+logger = get_logger(__name__)
 
 
 class OperationSafety(str, Enum):
@@ -476,7 +479,7 @@ def validate_environment_variable(key: str, value: Any) -> tuple[str, str]:
                 "Command injection characters are not allowed in environment variables."
             )
 
-    # Warn about potentially sensitive variables
+    # Warn about potentially sensitive variables being passed to containers
     sensitive_patterns = [
         "PASSWORD",
         "SECRET",
@@ -486,7 +489,9 @@ def validate_environment_variable(key: str, value: Any) -> tuple[str, str]:
     ]
 
     if any(pattern in key.upper() for pattern in sensitive_patterns):
-        # This would log a warning in production
-        pass
+        logger.warning(
+            f"Environment variable '{key}' appears to contain sensitive data. "
+            "Consider using Docker secrets or a secrets manager instead."
+        )
 
     return key, value_str

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,6 @@ def safety_config() -> SafetyConfig:
         allow_moderate_operations=True,
         allow_destructive_operations=True,
         allow_privileged_containers=False,
-        require_confirmation_for_destructive=False,
     )
 
 
@@ -39,7 +38,6 @@ def read_only_safety_config() -> SafetyConfig:
         allow_moderate_operations=False,
         allow_destructive_operations=False,
         allow_privileged_containers=False,
-        require_confirmation_for_destructive=True,
     )
 
 
@@ -159,5 +157,4 @@ def integration_test_config() -> Config:
     test_config.safety.allow_moderate_operations = True
     test_config.safety.allow_destructive_operations = True
     test_config.safety.allow_privileged_containers = True
-    test_config.safety.require_confirmation_for_destructive = False
     return test_config

--- a/tests/e2e/test_safety_enforcement_e2e.py
+++ b/tests/e2e/test_safety_enforcement_e2e.py
@@ -12,12 +12,72 @@ The tests create real Docker containers for testing and clean them up afterward.
 
 import asyncio
 import os
-from typing import Any
+from collections.abc import AsyncIterator
 
 import pytest
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 from mcp.types import CallToolResult
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+
+async def create_mcp_session(
+    allow_moderate: bool = True,
+    allow_destructive: bool = True,
+    extra_env: dict[str, str] | None = None,
+) -> AsyncIterator[ClientSession]:
+    """Create an MCP client session with configurable safety settings.
+
+    Args:
+        allow_moderate: Whether to allow MODERATE operations
+        allow_destructive: Whether to allow DESTRUCTIVE operations
+        extra_env: Additional environment variables to set
+
+    Yields:
+        ClientSession connected to the server
+
+    Note: Uses manual context manager enter/exit with error suppression to avoid
+    asyncio teardown issues with pytest-asyncio.
+    """
+    env = {
+        **os.environ,
+        "SECURITY_OAUTH_ENABLED": "false",
+        "SAFETY_ALLOW_MODERATE_OPERATIONS": str(allow_moderate).lower(),
+        "SAFETY_ALLOW_DESTRUCTIVE_OPERATIONS": str(allow_destructive).lower(),
+        **(extra_env or {}),
+    }
+
+    server_params = StdioServerParameters(
+        command="python",
+        args=["-m", "mcp_docker", "--transport", "stdio"],
+        env=env,
+    )
+
+    stdio_ctx = stdio_client(server_params)
+    read, write = await stdio_ctx.__aenter__()
+
+    try:
+        session_ctx = ClientSession(read, write)
+        session = await session_ctx.__aenter__()
+        try:
+            await session.initialize()
+            yield session
+        finally:
+            try:
+                await session_ctx.__aexit__(None, None, None)
+            except RuntimeError as e:
+                if "cancel scope" not in str(e):
+                    raise
+    finally:
+        try:
+            await stdio_ctx.__aexit__(None, None, None)
+        except RuntimeError as e:
+            if "cancel scope" not in str(e):
+                raise
+
 
 # ============================================================================
 # Test Fixtures
@@ -38,103 +98,21 @@ def skip_if_no_docker() -> None:
 
 
 @pytest.fixture
-async def mcp_client_session(skip_if_no_docker: None) -> Any:
-    """Create an MCP client connected to the server via stdio.
-
-    This simulates a real MCP client (like Claude Desktop) connecting to the server.
-
-    Note: Uses manual context manager enter/exit with error suppression to avoid
-    asyncio teardown issues with pytest-asyncio.
-    """
-    # Server parameters - connect to our MCP server via stdio
-    server_params = StdioServerParameters(
-        command="python",
-        args=["-m", "mcp_docker", "--transport", "stdio"],
-        env={
-            **os.environ,
-            # Disable OAuth for local stdio testing
-            "SECURITY_OAUTH_ENABLED": "false",
-            # Enable all operations for positive tests (we'll test blocking too)
-            "SAFETY_ALLOW_MODERATE_OPERATIONS": "true",
-            "SAFETY_ALLOW_DESTRUCTIVE_OPERATIONS": "true",
-        },
-    )
-
-    # Manually manage context managers to handle teardown errors
-    stdio_ctx = stdio_client(server_params)
-    read, write = await stdio_ctx.__aenter__()
-
-    try:
-        session_ctx = ClientSession(read, write)
-        session = await session_ctx.__aenter__()
-        try:
-            await session.initialize()
-            yield session
-        finally:
-            try:
-                await session_ctx.__aexit__(None, None, None)
-            except RuntimeError as e:
-                if "cancel scope" not in str(e):
-                    raise
-                # Suppress "cancel scope in different task" errors
-    finally:
-        try:
-            await stdio_ctx.__aexit__(None, None, None)
-        except RuntimeError as e:
-            if "cancel scope" not in str(e):
-                raise
-            # Suppress "cancel scope in different task" errors
+async def mcp_client_session(skip_if_no_docker: None) -> AsyncIterator[ClientSession]:
+    """Create an MCP client with all operations enabled."""
+    async for session in create_mcp_session(allow_moderate=True, allow_destructive=True):
+        yield session
 
 
 @pytest.fixture
-async def mcp_client_session_safe_only(skip_if_no_docker: None) -> Any:
-    """Create an MCP client with MODERATE and DESTRUCTIVE operations disabled.
-
-    This tests the safety enforcement - only SAFE (read-only) tools should work.
-
-    Note: Uses manual context manager enter/exit with error suppression to avoid
-    asyncio teardown issues with pytest-asyncio.
-    """
-    server_params = StdioServerParameters(
-        command="python",
-        args=["-m", "mcp_docker", "--transport", "stdio"],
-        env={
-            **os.environ,
-            "SECURITY_OAUTH_ENABLED": "false",
-            # CRITICAL: Disable moderate and destructive operations
-            "SAFETY_ALLOW_MODERATE_OPERATIONS": "false",
-            "SAFETY_ALLOW_DESTRUCTIVE_OPERATIONS": "false",
-        },
-    )
-
-    # Manually manage context managers to handle teardown errors
-    stdio_ctx = stdio_client(server_params)
-    read, write = await stdio_ctx.__aenter__()
-
-    try:
-        session_ctx = ClientSession(read, write)
-        session = await session_ctx.__aenter__()
-        try:
-            await session.initialize()
-            yield session
-        finally:
-            try:
-                await session_ctx.__aexit__(None, None, None)
-            except RuntimeError as e:
-                if "cancel scope" not in str(e):
-                    raise
-                # Suppress "cancel scope in different task" errors
-    finally:
-        try:
-            await stdio_ctx.__aexit__(None, None, None)
-        except RuntimeError as e:
-            if "cancel scope" not in str(e):
-                raise
-            # Suppress "cancel scope in different task" errors
+async def mcp_client_session_safe_only(skip_if_no_docker: None) -> AsyncIterator[ClientSession]:
+    """Create an MCP client with only SAFE operations allowed."""
+    async for session in create_mcp_session(allow_moderate=False, allow_destructive=False):
+        yield session
 
 
 @pytest.fixture
-async def test_container_id(skip_if_no_docker: None) -> Any:
+async def test_container_id(skip_if_no_docker: None) -> AsyncIterator[str]:
     """Create a test container for E2E tests and clean it up afterward."""
     import docker
 
@@ -142,7 +120,6 @@ async def test_container_id(skip_if_no_docker: None) -> Any:
     container = None
 
     try:
-        # Create a simple test container
         container = client.containers.create(
             image="alpine:latest",
             command="sleep 3600",
@@ -150,9 +127,7 @@ async def test_container_id(skip_if_no_docker: None) -> Any:
             detach=True,
         )
         yield container.id
-
     finally:
-        # Cleanup
         if container:
             try:
                 container.remove(force=True)
@@ -171,26 +146,14 @@ async def test_container_id(skip_if_no_docker: None) -> Any:
 async def test_safe_operation_list_containers_allowed(
     mcp_client_session: ClientSession,
 ) -> None:
-    """E2E: SAFE operation (list containers) should always be allowed.
-
-    This tests the full stack:
-    - MCP client sends tools/call request
-    - Server receives request through stdio
-    - Middleware processes request
-    - SafetyEnforcer checks tool is SAFE
-    - Tool executes
-    - Result returns to client
-    """
-    # Call the docker_list_containers tool (SAFE - read only)
+    """E2E: SAFE operation (list containers) should always be allowed."""
     result = await mcp_client_session.call_tool(
         name="docker_list_containers",
         arguments={"all": True},
     )
 
-    # Should succeed
     assert isinstance(result, CallToolResult)
     assert len(result.content) > 0
-    # Result should be valid JSON with container list
     assert "containers" in result.content[0].text or "[]" in result.content[0].text
 
 
@@ -201,16 +164,13 @@ async def test_safe_operation_inspect_container_allowed(
     test_container_id: str,
 ) -> None:
     """E2E: SAFE operation (inspect container) should always be allowed."""
-    # Call docker_inspect_container (SAFE - read only)
     result = await mcp_client_session.call_tool(
         name="docker_inspect_container",
         arguments={"container_id": test_container_id},
     )
 
-    # Should succeed
     assert isinstance(result, CallToolResult)
     assert len(result.content) > 0
-    # Should return container details
     content = result.content[0].text
     assert "Id" in content or "id" in content.lower()
 
@@ -226,20 +186,14 @@ async def test_moderate_operation_start_container_allowed_when_enabled(
     mcp_client_session: ClientSession,
     test_container_id: str,
 ) -> None:
-    """E2E: MODERATE operation (start container) allowed when config enables it.
-
-    This would have caught Bug #2 if start_container was blocked despite being enabled.
-    """
-    # Call docker_start_container (MODERATE - reversible)
+    """E2E: MODERATE operation (start container) allowed when config enables it."""
     result = await mcp_client_session.call_tool(
         name="docker_start_container",
         arguments={"container_id": test_container_id},
     )
 
-    # Should succeed because SAFETY_ALLOW_MODERATE_OPERATIONS=true
     assert isinstance(result, CallToolResult)
     assert len(result.content) > 0
-    # Tool returns JSON with container_id and status fields
     response_text = result.content[0].text.lower()
     assert "container_id" in response_text
     assert "status" in response_text
@@ -255,17 +209,13 @@ async def test_moderate_operation_blocked_when_disabled(
     """E2E: MODERATE operation should be blocked when config disables it.
 
     CRITICAL: This test would have caught Bug #2 (safety level always SAFE).
-    If the middleware was reading tool metadata correctly, this should raise an error.
     """
-    # Call docker_start_container (MODERATE) when moderate operations are disabled
     result = await mcp_client_session_safe_only.call_tool(
         name="docker_start_container",
         arguments={"container_id": test_container_id},
     )
 
-    # Should fail - check that error is returned
     assert isinstance(result, CallToolResult)
-    # MCP SDK wraps errors in CallToolResult with isError=True
     assert result.isError or "not allowed" in result.content[0].text.lower()
 
 
@@ -279,15 +229,10 @@ async def test_moderate_operation_blocked_when_disabled(
 async def test_destructive_operation_remove_container_allowed_when_enabled(
     mcp_client_session: ClientSession,
 ) -> None:
-    """E2E: DESTRUCTIVE operation (remove container) allowed when config enables it.
-
-    This creates and removes a container to test the full flow.
-    """
+    """E2E: DESTRUCTIVE operation (remove container) allowed when config enables it."""
     import docker
 
     client = docker.from_env()
-
-    # Create a temporary container to remove
     container = client.containers.create(
         image="alpine:latest",
         command="sleep 1",
@@ -296,22 +241,17 @@ async def test_destructive_operation_remove_container_allowed_when_enabled(
     temp_id = container.id
 
     try:
-        # Call docker_remove_container (DESTRUCTIVE - permanent deletion)
         result = await mcp_client_session.call_tool(
             name="docker_remove_container",
             arguments={"container_id": temp_id, "force": True},
         )
 
-        # Should succeed because SAFETY_ALLOW_DESTRUCTIVE_OPERATIONS=true
         assert isinstance(result, CallToolResult)
         assert not result.isError
 
-        # Verify container was actually deleted
         with pytest.raises(docker.errors.NotFound):
             client.containers.get(temp_id)
-
     finally:
-        # Cleanup if removal failed
         try:
             container.remove(force=True)
         except Exception:
@@ -327,14 +267,10 @@ async def test_destructive_operation_blocked_when_disabled(
     """E2E: DESTRUCTIVE operation should be blocked when config disables it.
 
     CRITICAL: This test would have caught Bug #2 (safety level always SAFE).
-    The middleware was defaulting all tools to SAFE, so docker_remove_container
-    (which is DESTRUCTIVE) was being allowed when it should have been blocked.
     """
     import docker
 
     client = docker.from_env()
-
-    # Create a temporary container (that we won't actually delete)
     container = client.containers.create(
         image="alpine:latest",
         command="sleep 1",
@@ -343,22 +279,17 @@ async def test_destructive_operation_blocked_when_disabled(
     temp_id = container.id
 
     try:
-        # Call docker_remove_container (DESTRUCTIVE) when destructive ops are disabled
         result = await mcp_client_session_safe_only.call_tool(
             name="docker_remove_container",
             arguments={"container_id": temp_id, "force": True},
         )
 
-        # Should fail with error
         assert isinstance(result, CallToolResult)
         assert result.isError or "not allowed" in result.content[0].text.lower()
 
-        # Verify container still exists (was not deleted)
         container_obj = client.containers.get(temp_id)
         assert container_obj is not None
-
     finally:
-        # Cleanup
         try:
             container.remove(force=True)
         except Exception:
@@ -374,75 +305,41 @@ async def test_destructive_operation_blocked_when_disabled(
 @pytest.mark.e2e
 @pytest.mark.asyncio
 async def test_tool_deny_list_enforcement() -> None:
-    """E2E: Tools on deny list should be blocked regardless of safety level.
+    """E2E: Tools on deny list should be blocked regardless of safety level."""
+    async for session in create_mcp_session(
+        extra_env={"SAFETY_DENIED_TOOLS": "docker_list_containers"}
+    ):
+        result = await session.call_tool(
+            name="docker_list_containers",
+            arguments={"all": True},
+        )
 
-    This tests that the SafetyEnforcer deny list works through the full stack.
-    """
-    # Create client with docker_list_containers on deny list
-    server_params = StdioServerParameters(
-        command="python",
-        args=["-m", "mcp_docker", "--transport", "stdio"],
-        env={
-            **os.environ,
-            "SECURITY_OAUTH_ENABLED": "false",
-            # Deny a normally-safe operation
-            "SAFETY_DENIED_TOOLS": "docker_list_containers",
-        },
-    )
-
-    async with stdio_client(server_params) as (read, write):
-        async with ClientSession(read, write) as session:
-            await session.initialize()
-
-            # Try to call the denied tool
-            result = await session.call_tool(
-                name="docker_list_containers",
-                arguments={"all": True},
-            )
-
-            # Should fail even though it's SAFE
-            assert isinstance(result, CallToolResult)
-            assert result.isError or "denied" in result.content[0].text.lower()
+        assert isinstance(result, CallToolResult)
+        assert result.isError or "denied" in result.content[0].text.lower()
 
 
 @pytest.mark.e2e
 @pytest.mark.asyncio
 async def test_tool_allow_list_enforcement() -> None:
-    """E2E: When allow list is set, only listed tools should work.
+    """E2E: When allow list is set, only listed tools should work."""
+    async for session in create_mcp_session(
+        extra_env={"SAFETY_ALLOWED_TOOLS": "docker_list_containers"}
+    ):
+        # Allowed tool should work
+        result1 = await session.call_tool(
+            name="docker_list_containers",
+            arguments={"all": True},
+        )
+        assert isinstance(result1, CallToolResult)
+        assert not result1.isError
 
-    This tests that the SafetyEnforcer allow list works through the full stack.
-    """
-    # Create client with only docker_list_containers allowed
-    server_params = StdioServerParameters(
-        command="python",
-        args=["-m", "mcp_docker", "--transport", "stdio"],
-        env={
-            **os.environ,
-            "SECURITY_OAUTH_ENABLED": "false",
-            # Only allow one tool
-            "SAFETY_ALLOWED_TOOLS": "docker_list_containers",
-        },
-    )
-
-    async with stdio_client(server_params) as (read, write):
-        async with ClientSession(read, write) as session:
-            await session.initialize()
-
-            # Allowed tool should work
-            result1 = await session.call_tool(
-                name="docker_list_containers",
-                arguments={"all": True},
-            )
-            assert isinstance(result1, CallToolResult)
-            assert not result1.isError
-
-            # Non-allowed tool should fail
-            result2 = await session.call_tool(
-                name="docker_list_images",
-                arguments={},
-            )
-            assert isinstance(result2, CallToolResult)
-            assert result2.isError or "not in allow list" in result2.content[0].text.lower()
+        # Non-allowed tool should fail
+        result2 = await session.call_tool(
+            name="docker_list_images",
+            arguments={},
+        )
+        assert isinstance(result2, CallToolResult)
+        assert result2.isError or "not in allow list" in result2.content[0].text.lower()
 
 
 # ============================================================================
@@ -458,16 +355,12 @@ async def test_middleware_executes_in_correct_order(
     """E2E: Verify middleware executes in correct order.
 
     CRITICAL: This would have caught Bug #1 (middleware signature mismatch).
-    If the middleware signature was wrong (context, call_next vs call_next, context),
-    this test would fail immediately when making the first tool call.
     """
-    # Make a simple tool call - if middleware signature is wrong, this will crash
     result = await mcp_client_session.call_tool(
         name="docker_list_containers",
         arguments={"all": True},
     )
 
-    # If we get here without crashing, middleware stack executed correctly
     assert isinstance(result, CallToolResult)
     assert not result.isError
 
@@ -477,23 +370,10 @@ async def test_middleware_executes_in_correct_order(
 async def test_full_stack_with_real_docker_operation(
     mcp_client_session: ClientSession,
 ) -> None:
-    """E2E: Test complete flow from MCP client to Docker operation and back.
-
-    This is the most realistic test - it exercises the entire stack:
-    1. MCP client sends request
-    2. Server receives via stdio
-    3. AuditMiddleware logs request
-    4. AuthMiddleware checks auth (stdio bypass)
-    5. SafetyMiddleware enforces safety (checks tool metadata)
-    6. RateLimitMiddleware checks limits
-    7. Tool executes Docker operation
-    8. Result flows back through stack to client
-    """
+    """E2E: Test complete flow from MCP client to Docker operation and back."""
     import docker
 
     client = docker.from_env()
-
-    # Create a test container
     container = client.containers.create(
         image="alpine:latest",
         command="echo 'E2E test'",
@@ -502,7 +382,7 @@ async def test_full_stack_with_real_docker_operation(
     )
 
     try:
-        # Step 1: List containers (should see our test container)
+        # Step 1: List containers
         list_result = await mcp_client_session.call_tool(
             name="docker_list_containers",
             arguments={"all": True},
@@ -510,7 +390,7 @@ async def test_full_stack_with_real_docker_operation(
         assert not list_result.isError
         assert "mcp-docker-e2e-full-stack" in list_result.content[0].text
 
-        # Step 2: Inspect the container (read metadata)
+        # Step 2: Inspect the container
         inspect_result = await mcp_client_session.call_tool(
             name="docker_inspect_container",
             arguments={"container_id": container.id},
@@ -518,14 +398,13 @@ async def test_full_stack_with_real_docker_operation(
         assert not inspect_result.isError
         assert container.id in inspect_result.content[0].text
 
-        # Step 3: Start the container (moderate operation)
+        # Step 3: Start the container
         start_result = await mcp_client_session.call_tool(
             name="docker_start_container",
             arguments={"container_id": container.id},
         )
         assert not start_result.isError
 
-        # Wait for container to finish
         await asyncio.sleep(1)
 
         # Step 4: Get container logs
@@ -536,19 +415,16 @@ async def test_full_stack_with_real_docker_operation(
         assert not logs_result.isError
         assert "E2E test" in logs_result.content[0].text
 
-        # Step 5: Remove container (destructive operation)
+        # Step 5: Remove container
         remove_result = await mcp_client_session.call_tool(
             name="docker_remove_container",
             arguments={"container_id": container.id, "force": True},
         )
         assert not remove_result.isError
 
-        # Verify container was deleted
         with pytest.raises(docker.errors.NotFound):
             client.containers.get(container.id)
-
     finally:
-        # Cleanup
         try:
             container.remove(force=True)
         except Exception:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -114,7 +114,6 @@ class TestSafetyConfig:
             assert config.allow_moderate_operations is True
             assert config.allow_destructive_operations is False
             assert config.allow_privileged_containers is False
-            assert config.require_confirmation_for_destructive is True
             assert config.max_concurrent_operations == 10
         finally:
             # Restore original value

--- a/tests/unit/test_fastmcp_helpers.py
+++ b/tests/unit/test_fastmcp_helpers.py
@@ -1,0 +1,119 @@
+"""Tests for FastMCP helper utilities."""
+
+from mcp_docker.utils.fastmcp_helpers import create_fastmcp_app, get_mcp_annotations
+from mcp_docker.utils.safety import OperationSafety
+from mcp_docker.version import __version__
+
+
+class TestCreateFastmcpApp:
+    """Tests for create_fastmcp_app function."""
+
+    def test_default_name(self) -> None:
+        """Test creating app with default name."""
+        app = create_fastmcp_app()
+
+        assert app.name == "mcp-docker"
+
+    def test_custom_name(self) -> None:
+        """Test creating app with custom name."""
+        app = create_fastmcp_app(name="my-custom-server")
+
+        assert app.name == "my-custom-server"
+
+    def test_version_is_set(self) -> None:
+        """Test that version is set from package version."""
+        app = create_fastmcp_app()
+
+        # FastMCP stores version - verify it's set
+        # Note: FastMCP 2.0 stores version in different ways depending on version
+        # We verify the app was created successfully with version info
+        assert app is not None
+        # Version should match package version
+        assert __version__ is not None
+
+    def test_returns_fastmcp_instance(self) -> None:
+        """Test that function returns a FastMCP instance."""
+        from fastmcp import FastMCP
+
+        app = create_fastmcp_app()
+
+        assert isinstance(app, FastMCP)
+
+    def test_empty_name_gets_default(self) -> None:
+        """Test creating app with empty name gets a default from FastMCP."""
+        app = create_fastmcp_app(name="")
+
+        # FastMCP generates a default name when given empty string
+        assert app.name is not None
+        assert len(app.name) > 0
+
+    def test_name_with_special_characters(self) -> None:
+        """Test creating app with special characters in name."""
+        app = create_fastmcp_app(name="mcp-docker-v2.0_test")
+
+        assert app.name == "mcp-docker-v2.0_test"
+
+
+class TestGetMcpAnnotations:
+    """Tests for get_mcp_annotations function."""
+
+    def test_safe_operation_annotations(self) -> None:
+        """Test annotations for SAFE operations."""
+        annotations = get_mcp_annotations(OperationSafety.SAFE)
+
+        assert annotations["readOnly"] is True
+        assert annotations["destructive"] is False
+
+    def test_moderate_operation_annotations(self) -> None:
+        """Test annotations for MODERATE operations."""
+        annotations = get_mcp_annotations(OperationSafety.MODERATE)
+
+        assert annotations["readOnly"] is False
+        assert annotations["destructive"] is False
+
+    def test_destructive_operation_annotations(self) -> None:
+        """Test annotations for DESTRUCTIVE operations."""
+        annotations = get_mcp_annotations(OperationSafety.DESTRUCTIVE)
+
+        assert annotations["readOnly"] is False
+        assert annotations["destructive"] is True
+
+    def test_returns_dict(self) -> None:
+        """Test that function returns a dictionary."""
+        annotations = get_mcp_annotations(OperationSafety.SAFE)
+
+        assert isinstance(annotations, dict)
+
+    def test_has_expected_keys(self) -> None:
+        """Test that annotations contain expected keys."""
+        annotations = get_mcp_annotations(OperationSafety.MODERATE)
+
+        assert "readOnly" in annotations
+        assert "destructive" in annotations
+
+    def test_only_has_expected_keys(self) -> None:
+        """Test that annotations only contain expected keys."""
+        annotations = get_mcp_annotations(OperationSafety.SAFE)
+
+        assert set(annotations.keys()) == {"readOnly", "destructive"}
+
+    def test_all_safety_levels_return_valid_annotations(self) -> None:
+        """Test that all safety levels return valid boolean annotations."""
+        for safety_level in OperationSafety:
+            annotations = get_mcp_annotations(safety_level)
+
+            assert isinstance(annotations["readOnly"], bool)
+            assert isinstance(annotations["destructive"], bool)
+
+    def test_annotations_are_mutually_consistent(self) -> None:
+        """Test that readOnly and destructive are consistent (can't be both True)."""
+        for safety_level in OperationSafety:
+            annotations = get_mcp_annotations(safety_level)
+
+            # A destructive operation cannot be read-only
+            if annotations["destructive"]:
+                assert annotations["readOnly"] is False
+
+            # A read-only operation cannot be destructive
+            if annotations["readOnly"]:
+                assert annotations["destructive"] is False

--- a/tests/unit/test_fastmcp_tools_combined_metadata.py
+++ b/tests/unit/test_fastmcp_tools_combined_metadata.py
@@ -55,230 +55,92 @@ def safety_config():
     return SafetyConfig()
 
 
-# Container Lifecycle Tool Metadata Tests
+class TestToolMetadata:
+    """Test tool metadata for all tool modules."""
 
-
-def test_create_container_tool_metadata(mock_docker_client):
-    """Test docker_create_container tool metadata."""
-    name, description, safety_level, idempotent, open_world, func = create_create_container_tool(
-        mock_docker_client, safety_config
+    @pytest.mark.parametrize(
+        "tool_creator,expected_name,expected_safety,needs_safety_config",
+        [
+            # Container lifecycle tools
+            (
+                create_create_container_tool,
+                "docker_create_container",
+                OperationSafety.MODERATE,
+                True,
+            ),
+            (
+                create_start_container_tool,
+                "docker_start_container",
+                OperationSafety.MODERATE,
+                False,
+            ),
+            (create_stop_container_tool, "docker_stop_container", OperationSafety.MODERATE, False),
+            (
+                create_restart_container_tool,
+                "docker_restart_container",
+                OperationSafety.MODERATE,
+                False,
+            ),
+            (
+                create_remove_container_tool,
+                "docker_remove_container",
+                OperationSafety.DESTRUCTIVE,
+                False,
+            ),
+            # Image tools
+            (create_list_images_tool, "docker_list_images", OperationSafety.SAFE, True),
+            (create_inspect_image_tool, "docker_inspect_image", OperationSafety.SAFE, False),
+            (create_image_history_tool, "docker_image_history", OperationSafety.SAFE, True),
+            (create_pull_image_tool, "docker_pull_image", OperationSafety.MODERATE, False),
+            (create_build_image_tool, "docker_build_image", OperationSafety.MODERATE, False),
+            (create_push_image_tool, "docker_push_image", OperationSafety.MODERATE, False),
+            (create_tag_image_tool, "docker_tag_image", OperationSafety.MODERATE, False),
+            (create_remove_image_tool, "docker_remove_image", OperationSafety.DESTRUCTIVE, False),
+            (create_prune_images_tool, "docker_prune_images", OperationSafety.DESTRUCTIVE, False),
+            # Network tools
+            (create_list_networks_tool, "docker_list_networks", OperationSafety.SAFE, True),
+            (create_inspect_network_tool, "docker_inspect_network", OperationSafety.SAFE, False),
+            (create_create_network_tool, "docker_create_network", OperationSafety.MODERATE, False),
+            (
+                create_connect_container_tool,
+                "docker_connect_container",
+                OperationSafety.MODERATE,
+                False,
+            ),
+            (
+                create_disconnect_container_tool,
+                "docker_disconnect_container",
+                OperationSafety.MODERATE,
+                False,
+            ),
+            (
+                create_remove_network_tool,
+                "docker_remove_network",
+                OperationSafety.DESTRUCTIVE,
+                False,
+            ),
+        ],
     )
-    assert name == "docker_create_container"
-    assert isinstance(description, str) and len(description) > 0
-    assert safety_level == OperationSafety.MODERATE
-    assert callable(func)
+    def test_tool_metadata(  # noqa: PLR0913
+        self,
+        mock_docker_client,
+        safety_config,
+        tool_creator,
+        expected_name,
+        expected_safety,
+        needs_safety_config,
+    ):
+        """Test tool metadata for container lifecycle, image, and network tools."""
+        if needs_safety_config:
+            name, description, safety_level, idempotent, open_world, func = tool_creator(
+                mock_docker_client, safety_config
+            )
+        else:
+            name, description, safety_level, idempotent, open_world, func = tool_creator(
+                mock_docker_client
+            )
 
-
-def test_start_container_tool_metadata(mock_docker_client):
-    """Test docker_start_container tool metadata."""
-    name, description, safety_level, idempotent, open_world, func = create_start_container_tool(
-        mock_docker_client
-    )
-    assert name == "docker_start_container"
-    assert isinstance(description, str) and len(description) > 0
-    assert safety_level == OperationSafety.MODERATE
-    assert callable(func)
-
-
-def test_stop_container_tool_metadata(mock_docker_client):
-    """Test docker_stop_container tool metadata."""
-    name, description, safety_level, idempotent, open_world, func = create_stop_container_tool(
-        mock_docker_client
-    )
-    assert name == "docker_stop_container"
-    assert isinstance(description, str) and len(description) > 0
-    assert safety_level == OperationSafety.MODERATE
-    assert callable(func)
-
-
-def test_restart_container_tool_metadata(mock_docker_client):
-    """Test docker_restart_container tool metadata."""
-    name, description, safety_level, idempotent, open_world, func = create_restart_container_tool(
-        mock_docker_client
-    )
-    assert name == "docker_restart_container"
-    assert isinstance(description, str) and len(description) > 0
-    assert safety_level == OperationSafety.MODERATE
-    assert callable(func)
-
-
-def test_remove_container_tool_metadata(mock_docker_client):
-    """Test docker_remove_container tool metadata."""
-    name, description, safety_level, idempotent, open_world, func = create_remove_container_tool(
-        mock_docker_client
-    )
-    assert name == "docker_remove_container"
-    assert isinstance(description, str) and len(description) > 0
-    assert safety_level == OperationSafety.DESTRUCTIVE
-    assert callable(func)
-
-
-# Image Tool Metadata Tests
-
-
-def test_list_images_tool_metadata(mock_docker_client):
-    """Test docker_list_images tool metadata."""
-    name, description, safety_level, idempotent, open_world, func = create_list_images_tool(
-        mock_docker_client, safety_config
-    )
-    assert name == "docker_list_images"
-    assert isinstance(description, str) and len(description) > 0
-    assert safety_level == OperationSafety.SAFE
-    assert callable(func)
-
-
-def test_inspect_image_tool_metadata(mock_docker_client):
-    """Test docker_inspect_image tool metadata."""
-    name, description, safety_level, idempotent, open_world, func = create_inspect_image_tool(
-        mock_docker_client
-    )
-    assert name == "docker_inspect_image"
-    assert isinstance(description, str) and len(description) > 0
-    assert safety_level == OperationSafety.SAFE
-    assert callable(func)
-
-
-def test_image_history_tool_metadata(mock_docker_client):
-    """Test docker_image_history tool metadata."""
-    name, description, safety_level, idempotent, open_world, func = create_image_history_tool(
-        mock_docker_client, safety_config
-    )
-    assert name == "docker_image_history"
-    assert isinstance(description, str) and len(description) > 0
-    assert safety_level == OperationSafety.SAFE
-    assert callable(func)
-
-
-def test_pull_image_tool_metadata(mock_docker_client):
-    """Test docker_pull_image tool metadata."""
-    name, description, safety_level, idempotent, open_world, func = create_pull_image_tool(
-        mock_docker_client
-    )
-    assert name == "docker_pull_image"
-    assert isinstance(description, str) and len(description) > 0
-    assert safety_level == OperationSafety.MODERATE
-    assert callable(func)
-
-
-def test_build_image_tool_metadata(mock_docker_client):
-    """Test docker_build_image tool metadata."""
-    name, description, safety_level, idempotent, open_world, func = create_build_image_tool(
-        mock_docker_client
-    )
-    assert name == "docker_build_image"
-    assert isinstance(description, str) and len(description) > 0
-    assert safety_level == OperationSafety.MODERATE
-    assert callable(func)
-
-
-def test_push_image_tool_metadata(mock_docker_client):
-    """Test docker_push_image tool metadata."""
-    name, description, safety_level, idempotent, open_world, func = create_push_image_tool(
-        mock_docker_client
-    )
-    assert name == "docker_push_image"
-    assert isinstance(description, str) and len(description) > 0
-    assert safety_level == OperationSafety.MODERATE
-    assert callable(func)
-
-
-def test_tag_image_tool_metadata(mock_docker_client):
-    """Test docker_tag_image tool metadata."""
-    name, description, safety_level, idempotent, open_world, func = create_tag_image_tool(
-        mock_docker_client
-    )
-    assert name == "docker_tag_image"
-    assert isinstance(description, str) and len(description) > 0
-    assert safety_level == OperationSafety.MODERATE
-    assert callable(func)
-
-
-def test_remove_image_tool_metadata(mock_docker_client):
-    """Test docker_remove_image tool metadata."""
-    name, description, safety_level, idempotent, open_world, func = create_remove_image_tool(
-        mock_docker_client
-    )
-    assert name == "docker_remove_image"
-    assert isinstance(description, str) and len(description) > 0
-    assert safety_level == OperationSafety.DESTRUCTIVE
-    assert callable(func)
-
-
-def test_prune_images_tool_metadata(mock_docker_client):
-    """Test docker_prune_images tool metadata."""
-    name, description, safety_level, idempotent, open_world, func = create_prune_images_tool(
-        mock_docker_client
-    )
-    assert name == "docker_prune_images"
-    assert isinstance(description, str) and len(description) > 0
-    assert safety_level == OperationSafety.DESTRUCTIVE
-    assert callable(func)
-
-
-# Network Tool Metadata Tests
-
-
-def test_list_networks_tool_metadata(mock_docker_client):
-    """Test docker_list_networks tool metadata."""
-    name, description, safety_level, idempotent, open_world, func = create_list_networks_tool(
-        mock_docker_client, safety_config
-    )
-    assert name == "docker_list_networks"
-    assert isinstance(description, str) and len(description) > 0
-    assert safety_level == OperationSafety.SAFE
-    assert callable(func)
-
-
-def test_inspect_network_tool_metadata(mock_docker_client):
-    """Test docker_inspect_network tool metadata."""
-    name, description, safety_level, idempotent, open_world, func = create_inspect_network_tool(
-        mock_docker_client
-    )
-    assert name == "docker_inspect_network"
-    assert isinstance(description, str) and len(description) > 0
-    assert safety_level == OperationSafety.SAFE
-    assert callable(func)
-
-
-def test_create_network_tool_metadata(mock_docker_client):
-    """Test docker_create_network tool metadata."""
-    name, description, safety_level, idempotent, open_world, func = create_create_network_tool(
-        mock_docker_client
-    )
-    assert name == "docker_create_network"
-    assert isinstance(description, str) and len(description) > 0
-    assert safety_level == OperationSafety.MODERATE
-    assert callable(func)
-
-
-def test_connect_container_tool_metadata(mock_docker_client):
-    """Test docker_connect_container tool metadata."""
-    name, description, safety_level, idempotent, open_world, func = create_connect_container_tool(
-        mock_docker_client
-    )
-    assert name == "docker_connect_container"
-    assert isinstance(description, str) and len(description) > 0
-    assert safety_level == OperationSafety.MODERATE
-    assert callable(func)
-
-
-def test_disconnect_container_tool_metadata(mock_docker_client):
-    """Test docker_disconnect_container tool metadata."""
-    name, description, safety_level, idempotent, open_world, func = (
-        create_disconnect_container_tool(mock_docker_client)
-    )
-    assert name == "docker_disconnect_container"
-    assert isinstance(description, str) and len(description) > 0
-    assert safety_level == OperationSafety.MODERATE
-    assert callable(func)
-
-
-def test_remove_network_tool_metadata(mock_docker_client):
-    """Test docker_remove_network tool metadata."""
-    name, description, safety_level, idempotent, open_world, func = create_remove_network_tool(
-        mock_docker_client
-    )
-    assert name == "docker_remove_network"
-    assert isinstance(description, str) and len(description) > 0
-    assert safety_level == OperationSafety.DESTRUCTIVE
-    assert callable(func)
+        assert name == expected_name
+        assert isinstance(description, str) and len(description) > 0
+        assert safety_level == expected_safety
+        assert callable(func)

--- a/tests/unit/test_fastmcp_tools_container_lifecycle.py
+++ b/tests/unit/test_fastmcp_tools_container_lifecycle.py
@@ -28,32 +28,45 @@ from mcp_docker.utils.errors import (
 )
 
 
+# Module-level fixtures to avoid duplication across test classes
+@pytest.fixture
+def mock_docker_client():
+    """Create a mock Docker client."""
+    client = Mock(spec=DockerClientWrapper)
+    client.client = Mock()
+    client.client.containers = Mock()
+    return client
+
+
+@pytest.fixture
+def safety_config():
+    """Create safety config."""
+    return SafetyConfig()
+
+
 class TestCreateContainerInputValidation:
     """Test CreateContainerInput Pydantic model validation."""
 
-    def test_json_string_parsing_ports(self):
-        """Test that ports JSON string is parsed correctly."""
-        input_data = CreateContainerInput(
-            image="nginx",
-            ports='{"80": 8080}',
-        )
-        assert input_data.ports == {"80": 8080}
-
-    def test_json_string_parsing_environment(self):
-        """Test that environment JSON string is parsed correctly."""
-        input_data = CreateContainerInput(
-            image="nginx",
-            environment='{"DEBUG": "true", "PORT": "3000"}',
-        )
-        assert input_data.environment == {"DEBUG": "true", "PORT": "3000"}
-
-    def test_json_string_parsing_volumes(self):
-        """Test that volumes JSON string is parsed correctly."""
-        input_data = CreateContainerInput(
-            image="nginx",
-            volumes='{"/host/path": {"bind": "/container/path", "mode": "rw"}}',
-        )
-        assert input_data.volumes == {"/host/path": {"bind": "/container/path", "mode": "rw"}}
+    @pytest.mark.parametrize(
+        "field,json_value,expected",
+        [
+            ("ports", '{"80": 8080}', {"80": 8080}),
+            (
+                "environment",
+                '{"DEBUG": "true", "PORT": "3000"}',
+                {"DEBUG": "true", "PORT": "3000"},
+            ),
+            (
+                "volumes",
+                '{"/host/path": {"bind": "/container/path", "mode": "rw"}}',
+                {"/host/path": {"bind": "/container/path", "mode": "rw"}},
+            ),
+        ],
+    )
+    def test_json_string_parsing(self, field, json_value, expected):
+        """Test that JSON string fields are parsed correctly."""
+        input_data = CreateContainerInput(image="nginx", **{field: json_value})
+        assert getattr(input_data, field) == expected
 
     def test_dict_passthrough(self):
         """Test that dict values are passed through."""
@@ -71,153 +84,112 @@ class TestCreateContainerInputValidation:
 class TestValidatePortMappings:
     """Test _validate_port_mappings helper function."""
 
-    def test_validate_port_mappings_success(self):
+    @pytest.mark.parametrize(
+        "ports",
+        [
+            {"80": 8080, "443": 8443},  # Basic mapping
+            {"80/tcp": 8080},  # TCP protocol
+            {"80": None},  # Expose without mapping
+            {"80": ("127.0.0.1", 8080)},  # Tuple value
+        ],
+    )
+    def test_validate_port_mappings_success(self, ports):
         """Test successful port mapping validation."""
-        ports = {"80": 8080, "443": 8443}
-        # Should not raise
-        _validate_port_mappings(ports)
-
-    def test_validate_port_mappings_tcp_protocol(self):
-        """Test port mapping with explicit TCP protocol."""
-        ports = {"80/tcp": 8080}
-        # Should not raise
-        _validate_port_mappings(ports)
-
-    def test_validate_port_mappings_none_value(self):
-        """Test port mapping with None value (expose without mapping)."""
-        ports = {"80": None}
-        # Should not raise (None values are skipped in validation)
-        _validate_port_mappings(ports)
-
-    def test_validate_port_mappings_tuple_value(self):
-        """Test port mapping with tuple value."""
-        ports = {"80": ("127.0.0.1", 8080)}
-        # Should not raise (tuple values are skipped in validation)
-        _validate_port_mappings(ports)
+        _validate_port_mappings(ports)  # Should not raise
 
 
 class TestValidateVolumeMounts:
     """Test _validate_volume_mounts helper function."""
 
-    def test_validate_volume_mounts_success(self):
-        """Test successful volume mount validation."""
-        volumes = {"/tmp/data": {"bind": "/data", "mode": "rw"}}
-        safety_config = SafetyConfig()
-        # Should not raise
-        _validate_volume_mounts(volumes, safety_config)
-
-    def test_validate_volume_mounts_yolo_mode(self):
-        """Test volume mount validation in YOLO mode."""
-        volumes = {"/etc": {"bind": "/host-etc", "mode": "ro"}}
-        safety_config = SafetyConfig(yolo_mode=True)
-        # Should not raise in YOLO mode
-        _validate_volume_mounts(volumes, safety_config)
-
-    def test_validate_volume_mounts_blocked_path(self):
-        """Test volume mount validation with blocked path."""
-        volumes = {"/etc": {"bind": "/host-etc", "mode": "rw"}}
-        safety_config = SafetyConfig(yolo_mode=False)
-        # Should raise UnsafeOperationError for /etc
-        with pytest.raises(UnsafeOperationError, match="blocked"):
-            _validate_volume_mounts(volumes, safety_config)
+    @pytest.mark.parametrize(
+        "volumes,yolo_mode,should_pass,error_match",
+        [
+            ({"/tmp/data": {"bind": "/data", "mode": "rw"}}, False, True, None),
+            ({"/etc": {"bind": "/host-etc", "mode": "ro"}}, True, True, None),
+            ({"/etc": {"bind": "/host-etc", "mode": "rw"}}, False, False, "blocked"),
+        ],
+    )
+    def test_validate_volume_mounts(self, volumes, yolo_mode, should_pass, error_match):
+        """Test volume mount validation."""
+        config = SafetyConfig(yolo_mode=yolo_mode)
+        if should_pass:
+            _validate_volume_mounts(volumes, config)
+        else:
+            with pytest.raises(UnsafeOperationError, match=error_match):
+                _validate_volume_mounts(volumes, config)
 
     def test_validate_volume_mounts_allowlist(self):
         """Test volume mount validation with allowlist."""
         volumes = {"/custom/path": {"bind": "/data", "mode": "rw"}}
-        safety_config = SafetyConfig(
-            volume_mount_allowlist=["/tmp", "/var/tmp"],
-            yolo_mode=False,
-        )
-        # Should raise UnsafeOperationError (not in allowlist)
+        config = SafetyConfig(volume_mount_allowlist=["/tmp", "/var/tmp"], yolo_mode=False)
         with pytest.raises(UnsafeOperationError, match="not in allowed paths"):
-            _validate_volume_mounts(volumes, safety_config)
+            _validate_volume_mounts(volumes, config)
 
 
 class TestValidateEnvironmentVars:
     """Test _validate_environment_vars helper function."""
 
-    def test_validate_environment_vars_success(self):
-        """Test successful environment variable validation."""
-        environment = {"DEBUG": "true", "PORT": "3000", "DATABASE_URL": "postgres://localhost"}
-        # Should not raise
-        _validate_environment_vars(environment)
-
-    def test_validate_environment_vars_with_path(self):
-        """Test environment variable with PATH key (should be allowed)."""
-        environment = {"PATH": "/usr/bin"}
-        # Should not raise (PATH is allowed)
-        _validate_environment_vars(environment)
-
-    def test_validate_environment_vars_command_substitution(self):
-        """Test environment variable with command substitution."""
-        environment = {"CMD": "$(rm -rf /)"}
-        # Should raise ValidationError for command substitution
-        with pytest.raises(ValidationError, match="dangerous character"):
-            _validate_environment_vars(environment)
-
-    def test_validate_environment_vars_backtick(self):
-        """Test environment variable with backtick."""
-        environment = {"CMD": "`whoami`"}
-        # Should raise ValidationError for backtick
-        with pytest.raises(ValidationError, match="dangerous character"):
-            _validate_environment_vars(environment)
-
-    def test_validate_environment_vars_semicolon(self):
-        """Test environment variable with semicolon."""
-        environment = {"CMD": "echo hello; rm -rf /"}
-        # Should raise ValidationError for semicolon
-        with pytest.raises(ValidationError, match="dangerous character"):
-            _validate_environment_vars(environment)
+    @pytest.mark.parametrize(
+        "env,should_pass,error_match",
+        [
+            ({"DEBUG": "true", "PORT": "3000"}, True, None),
+            ({"PATH": "/usr/bin"}, True, None),
+            ({"CMD": "$(rm -rf /)"}, False, "dangerous character"),
+            ({"CMD": "`whoami`"}, False, "dangerous character"),
+            ({"CMD": "echo hello; rm -rf /"}, False, "dangerous character"),
+        ],
+    )
+    def test_validate_environment_vars(self, env, should_pass, error_match):
+        """Test environment variable validation."""
+        if should_pass:
+            _validate_environment_vars(env)
+        else:
+            with pytest.raises(ValidationError, match=error_match):
+                _validate_environment_vars(env)
 
 
 class TestValidateCreateContainerInputs:
     """Test _validate_create_container_inputs helper function."""
 
-    def test_validate_all_inputs_success(self):
-        """Test validation of all container creation inputs."""
-        input_data = CreateContainerInput(
-            image="nginx",
-            name="my-nginx",
-            command=["nginx", "-g", "daemon off;"],  # Use list format
-            mem_limit="512m",
-            ports={"80": 8080},
-            volumes={"/tmp/data": {"bind": "/data", "mode": "rw"}},
-            environment={"DEBUG": "false"},
-        )
-        safety_config = SafetyConfig()
-        # Should not raise
-        _validate_create_container_inputs(input_data, safety_config)
-
-    def test_validate_without_optional_fields(self):
-        """Test validation with minimal required fields."""
-        input_data = CreateContainerInput(image="nginx")
-        safety_config = SafetyConfig()
-        # Should not raise
-        _validate_create_container_inputs(input_data, safety_config)
-
-    def test_validate_invalid_name(self):
-        """Test validation with invalid container name."""
-        input_data = CreateContainerInput(image="nginx", name="Invalid Name!")
-        safety_config = SafetyConfig()
-        # Should raise ValidationError for invalid name
-        with pytest.raises(ValidationError):
-            _validate_create_container_inputs(input_data, safety_config)
-
-    def test_validate_invalid_command(self):
-        """Test validation with command containing special characters."""
-        input_data = CreateContainerInput(image="nginx", command="echo hello && rm -rf /")
-        safety_config = SafetyConfig()
-        # Should raise ValidationError for command with &&
-        with pytest.raises(ValidationError, match="dangerous patterns"):
-            _validate_create_container_inputs(input_data, safety_config)
-
-    def test_validate_invalid_memory(self):
-        """Test validation with invalid memory limit."""
-        input_data = CreateContainerInput(image="nginx", mem_limit="invalid")
-        safety_config = SafetyConfig()
-        # Should raise ValidationError for invalid memory format
-        with pytest.raises(ValidationError):
-            _validate_create_container_inputs(input_data, safety_config)
+    @pytest.mark.parametrize(
+        "kwargs,should_pass,error_match",
+        [
+            # Full valid input
+            (
+                {
+                    "image": "nginx",
+                    "name": "my-nginx",
+                    "command": ["nginx", "-g", "daemon off;"],
+                    "mem_limit": "512m",
+                    "ports": {"80": 8080},
+                    "volumes": {"/tmp/data": {"bind": "/data", "mode": "rw"}},
+                    "environment": {"DEBUG": "false"},
+                },
+                True,
+                None,
+            ),
+            # Minimal input
+            ({"image": "nginx"}, True, None),
+            # Invalid name
+            ({"image": "nginx", "name": "Invalid Name!"}, False, None),
+            # Invalid command
+            ({"image": "nginx", "command": "echo hello && rm -rf /"}, False, "dangerous patterns"),
+            # Invalid memory
+            ({"image": "nginx", "mem_limit": "invalid"}, False, None),
+        ],
+    )
+    def test_validate_create_container_inputs(self, kwargs, should_pass, error_match):
+        """Test container creation input validation."""
+        input_data = CreateContainerInput(**kwargs)
+        config = SafetyConfig()
+        if should_pass:
+            _validate_create_container_inputs(input_data, config)
+        elif error_match:
+            with pytest.raises(ValidationError, match=error_match):
+                _validate_create_container_inputs(input_data, config)
+        else:
+            with pytest.raises(ValidationError):
+                _validate_create_container_inputs(input_data, config)
 
 
 class TestPrepareCreateContainerKwargs:
@@ -261,584 +233,257 @@ class TestPrepareCreateContainerKwargs:
         assert "auto_remove" not in kwargs
 
 
+class TestContainerNotFoundErrors:
+    """Test container not found error handling across lifecycle tools."""
+
+    @pytest.mark.parametrize(
+        "tool_creator,call_kwargs",
+        [
+            (create_start_container_tool, {"container_id": "nonexistent"}),
+            (create_stop_container_tool, {"container_id": "nonexistent"}),
+            (create_restart_container_tool, {"container_id": "nonexistent"}),
+            (create_remove_container_tool, {"container_id": "nonexistent"}),
+        ],
+    )
+    def test_container_not_found(self, mock_docker_client, tool_creator, call_kwargs):
+        """Test that ContainerNotFound is raised when container doesn't exist."""
+        mock_docker_client.client.containers.get.side_effect = NotFound("Container not found")
+        *_, func = tool_creator(mock_docker_client)
+
+        with pytest.raises(ContainerNotFound, match="Container not found"):
+            func(**call_kwargs)
+
+
+class TestAPIErrors:
+    """Test API error handling across lifecycle tools."""
+
+    @pytest.mark.parametrize(
+        "tool_creator,needs_safety_config,container_method,error_match",
+        [
+            (create_create_container_tool, True, "create", "Failed to create container"),
+            (create_start_container_tool, False, "start", "Failed to start container"),
+            (create_stop_container_tool, False, "stop", "Failed to stop container"),
+            (create_restart_container_tool, False, "restart", "Failed to restart container"),
+            (create_remove_container_tool, False, "remove", "Failed to remove container"),
+        ],
+    )
+    def test_api_error(  # noqa: PLR0913
+        self,
+        mock_docker_client,
+        safety_config,
+        tool_creator,
+        needs_safety_config,
+        container_method,
+        error_match,
+    ):
+        """Test that DockerOperationError is raised on API errors."""
+        if container_method == "create":
+            mock_docker_client.client.containers.create.side_effect = APIError("API failed")
+        else:
+            container = Mock()
+            container.status = "running" if container_method != "start" else "exited"
+            getattr(container, container_method).side_effect = APIError("API failed")
+            mock_docker_client.client.containers.get.return_value = container
+
+        if needs_safety_config:
+            *_, func = tool_creator(mock_docker_client, safety_config)
+            call_kwargs = {"image": "nginx"} if container_method == "create" else {}
+        else:
+            *_, func = tool_creator(mock_docker_client)
+            call_kwargs = {"container_id": "abc123"}
+
+        with pytest.raises(DockerOperationError, match=error_match):
+            func(**call_kwargs)
+
+
 class TestCreateContainerTool:
     """Test docker_create_container tool."""
 
-    @pytest.fixture
-    def mock_docker_client(self):
-        """Create a mock Docker client."""
-        client = Mock(spec=DockerClientWrapper)
-        client.client = Mock()
-        client.client.containers = Mock()
-        return client
-
-    @pytest.fixture
-    def safety_config(self):
-        """Create safety config."""
-        return SafetyConfig()
-
     def test_create_container_minimal(self, mock_docker_client, safety_config):
         """Test creating container with minimal parameters."""
-        # Mock container object
         container = Mock()
         container.id = "abc123"
         container.name = "my-nginx"
-
         mock_docker_client.client.containers.create.return_value = container
 
-        # Get the create function
-        _, _, _, _, _, create_func = create_create_container_tool(mock_docker_client, safety_config)
-
-        # Execute
+        *_, create_func = create_create_container_tool(mock_docker_client, safety_config)
         result = create_func(image="nginx")
 
-        # Verify
         assert result["container_id"] == "abc123"
         assert result["name"] == "my-nginx"
-        assert result["warnings"] is None
         mock_docker_client.client.containers.create.assert_called_once_with(image="nginx")
 
-    def test_create_container_with_name(self, mock_docker_client, safety_config):
-        """Test creating container with custom name."""
-        container = Mock()
-        container.id = "abc123"
-        container.name = "custom-name"
-
-        mock_docker_client.client.containers.create.return_value = container
-
-        # Get the create function
-        _, _, _, _, _, create_func = create_create_container_tool(mock_docker_client, safety_config)
-
-        # Execute
-        create_func(image="nginx", name="custom-name")
-
-        # Verify
-        call_kwargs = mock_docker_client.client.containers.create.call_args.kwargs
-        assert call_kwargs["name"] == "custom-name"
-
-    def test_create_container_with_command(self, mock_docker_client, safety_config):
-        """Test creating container with command."""
-        container = Mock()
-        container.id = "abc123"
-        container.name = "my-nginx"
-
-        mock_docker_client.client.containers.create.return_value = container
-
-        # Get the create function
-        _, _, _, _, _, create_func = create_create_container_tool(mock_docker_client, safety_config)
-
-        # Execute with command (use list format to avoid special characters validation)
-        create_func(image="nginx", command=["nginx", "-g", "daemon off;"])
-
-        # Verify
-        call_kwargs = mock_docker_client.client.containers.create.call_args.kwargs
-        assert call_kwargs["command"] == ["nginx", "-g", "daemon off;"]
-
-    def test_create_container_with_environment(self, mock_docker_client, safety_config):
-        """Test creating container with environment variables."""
+    @pytest.mark.parametrize(
+        "extra_kwargs,expected_call_kwarg",
+        [
+            ({"name": "custom-name"}, ("name", "custom-name")),
+            (
+                {"command": ["nginx", "-g", "daemon off;"]},
+                ("command", ["nginx", "-g", "daemon off;"]),
+            ),
+            ({"environment": {"DEBUG": "false"}}, ("environment", {"DEBUG": "false"})),
+            ({"ports": {"80": 8080}}, ("ports", {"80": 8080})),
+            (
+                {"volumes": {"/tmp/data": {"bind": "/data"}}},
+                ("volumes", {"/tmp/data": {"bind": "/data"}}),
+            ),
+            ({"mem_limit": "512m"}, ("mem_limit", "512m")),
+            ({"cpu_shares": 512}, ("cpu_shares", 512)),
+            ({"remove": True}, ("auto_remove", True)),
+        ],
+    )
+    def test_create_container_with_options(
+        self, mock_docker_client, safety_config, extra_kwargs, expected_call_kwarg
+    ):
+        """Test creating container with various options."""
         container = Mock()
         container.id = "abc123"
         container.name = "my-nginx"
-
         mock_docker_client.client.containers.create.return_value = container
 
-        # Get the create function
-        _, _, _, _, _, create_func = create_create_container_tool(mock_docker_client, safety_config)
+        *_, create_func = create_create_container_tool(mock_docker_client, safety_config)
+        create_func(image="nginx", **extra_kwargs)
 
-        # Execute with environment
-        env = {"DEBUG": "false", "PORT": "3000"}
-        create_func(image="nginx", environment=env)
-
-        # Verify
         call_kwargs = mock_docker_client.client.containers.create.call_args.kwargs
-        assert call_kwargs["environment"] == env
-
-    def test_create_container_with_ports(self, mock_docker_client, safety_config):
-        """Test creating container with port mappings."""
-        container = Mock()
-        container.id = "abc123"
-        container.name = "my-nginx"
-
-        mock_docker_client.client.containers.create.return_value = container
-
-        # Get the create function
-        _, _, _, _, _, create_func = create_create_container_tool(mock_docker_client, safety_config)
-
-        # Execute with ports
-        ports = {"80": 8080, "443": 8443}
-        create_func(image="nginx", ports=ports)
-
-        # Verify
-        call_kwargs = mock_docker_client.client.containers.create.call_args.kwargs
-        assert call_kwargs["ports"] == ports
-
-    def test_create_container_with_volumes(self, mock_docker_client, safety_config):
-        """Test creating container with volume mounts."""
-        container = Mock()
-        container.id = "abc123"
-        container.name = "my-nginx"
-
-        mock_docker_client.client.containers.create.return_value = container
-
-        # Get the create function
-        _, _, _, _, _, create_func = create_create_container_tool(mock_docker_client, safety_config)
-
-        # Execute with volumes
-        volumes = {"/tmp/data": {"bind": "/data", "mode": "rw"}}
-        create_func(image="nginx", volumes=volumes)
-
-        # Verify
-        call_kwargs = mock_docker_client.client.containers.create.call_args.kwargs
-        assert call_kwargs["volumes"] == volumes
-
-    def test_create_container_with_resource_limits(self, mock_docker_client, safety_config):
-        """Test creating container with resource limits."""
-        container = Mock()
-        container.id = "abc123"
-        container.name = "my-nginx"
-
-        mock_docker_client.client.containers.create.return_value = container
-
-        # Get the create function
-        _, _, _, _, _, create_func = create_create_container_tool(mock_docker_client, safety_config)
-
-        # Execute with resource limits
-        create_func(image="nginx", mem_limit="512m", cpu_shares=512)
-
-        # Verify
-        call_kwargs = mock_docker_client.client.containers.create.call_args.kwargs
-        assert call_kwargs["mem_limit"] == "512m"
-        assert call_kwargs["cpu_shares"] == 512
-
-    def test_create_container_with_remove(self, mock_docker_client, safety_config):
-        """Test creating container with auto_remove flag."""
-        container = Mock()
-        container.id = "abc123"
-        container.name = "my-nginx"
-
-        mock_docker_client.client.containers.create.return_value = container
-
-        # Get the create function
-        _, _, _, _, _, create_func = create_create_container_tool(mock_docker_client, safety_config)
-
-        # Execute with remove=True
-        create_func(image="nginx", remove=True)
-
-        # Verify
-        call_kwargs = mock_docker_client.client.containers.create.call_args.kwargs
-        assert call_kwargs["auto_remove"] is True
-
-    def test_create_container_api_error(self, mock_docker_client, safety_config):
-        """Test container creation with API error."""
-        mock_docker_client.client.containers.create.side_effect = APIError("Create failed")
-
-        # Get the create function
-        _, _, _, _, _, create_func = create_create_container_tool(mock_docker_client, safety_config)
-
-        # Execute and expect error
-        with pytest.raises(DockerOperationError, match="Failed to create container"):
-            create_func(image="nginx")
+        key, value = expected_call_kwarg
+        assert call_kwargs[key] == value
 
 
 class TestStartContainerTool:
     """Test docker_start_container tool."""
 
-    @pytest.fixture
-    def mock_docker_client(self):
-        """Create a mock Docker client."""
-        client = Mock(spec=DockerClientWrapper)
-        client.client = Mock()
-        client.client.containers = Mock()
-        return client
-
     def test_start_container_success(self, mock_docker_client):
         """Test successfully starting a stopped container."""
-        # Mock container object
         container = Mock()
         container.id = "abc123"
         container.status = "exited"
-        container.start = Mock()
-        container.reload = Mock()
-
-        # After reload, status should be running
-        def reload_side_effect():
-            container.status = "running"
-
-        container.reload.side_effect = reload_side_effect
-
+        container.reload = Mock(side_effect=lambda: setattr(container, "status", "running"))
         mock_docker_client.client.containers.get.return_value = container
 
-        # Get the start function
-        _, _, _, _, _, start_func = create_start_container_tool(mock_docker_client)
-
-        # Execute
+        *_, start_func = create_start_container_tool(mock_docker_client)
         result = start_func(container_id="abc123")
 
-        # Verify
         assert result["container_id"] == "abc123"
         assert result["status"] == "running"
         container.start.assert_called_once()
-        container.reload.assert_called_once()
 
     def test_start_container_already_running(self, mock_docker_client):
         """Test starting an already running container (idempotent)."""
-        # Mock container object
         container = Mock()
         container.id = "abc123"
         container.status = "running"
-
         mock_docker_client.client.containers.get.return_value = container
 
-        # Get the start function
-        _, _, _, _, _, start_func = create_start_container_tool(mock_docker_client)
-
-        # Execute
+        *_, start_func = create_start_container_tool(mock_docker_client)
         result = start_func(container_id="abc123")
 
-        # Verify - should return success without calling start()
-        assert result["container_id"] == "abc123"
         assert result["status"] == "running"
-
-    def test_start_container_not_found(self, mock_docker_client):
-        """Test starting non-existent container."""
-        mock_docker_client.client.containers.get.side_effect = NotFound("Container not found")
-
-        # Get the start function
-        _, _, _, _, _, start_func = create_start_container_tool(mock_docker_client)
-
-        # Execute and expect error
-        with pytest.raises(ContainerNotFound, match="Container not found"):
-            start_func(container_id="nonexistent")
-
-    def test_start_container_api_error(self, mock_docker_client):
-        """Test starting container with API error."""
-        container = Mock()
-        container.status = "exited"
-        container.start.side_effect = APIError("Start failed")
-
-        mock_docker_client.client.containers.get.return_value = container
-
-        # Get the start function
-        _, _, _, _, _, start_func = create_start_container_tool(mock_docker_client)
-
-        # Execute and expect error
-        with pytest.raises(DockerOperationError, match="Failed to start container"):
-            start_func(container_id="abc123")
 
 
 class TestStopContainerTool:
     """Test docker_stop_container tool."""
 
-    @pytest.fixture
-    def mock_docker_client(self):
-        """Create a mock Docker client."""
-        client = Mock(spec=DockerClientWrapper)
-        client.client = Mock()
-        client.client.containers = Mock()
-        return client
-
     def test_stop_container_success(self, mock_docker_client):
         """Test successfully stopping a running container."""
-        # Mock container object
         container = Mock()
         container.id = "abc123"
         container.status = "running"
-        container.stop = Mock()
-        container.reload = Mock()
-
-        # After reload, status should be exited
-        def reload_side_effect():
-            container.status = "exited"
-
-        container.reload.side_effect = reload_side_effect
-
+        container.reload = Mock(side_effect=lambda: setattr(container, "status", "exited"))
         mock_docker_client.client.containers.get.return_value = container
 
-        # Get the stop function
-        _, _, _, _, _, stop_func = create_stop_container_tool(mock_docker_client)
-
-        # Execute
+        *_, stop_func = create_stop_container_tool(mock_docker_client)
         result = stop_func(container_id="abc123")
 
-        # Verify
-        assert result["container_id"] == "abc123"
         assert result["status"] == "exited"
         container.stop.assert_called_once_with(timeout=10)
-        container.reload.assert_called_once()
 
     def test_stop_container_with_custom_timeout(self, mock_docker_client):
         """Test stopping container with custom timeout."""
         container = Mock()
         container.id = "abc123"
         container.status = "running"
-        container.stop = Mock()
-        container.reload = Mock()
-
-        def reload_side_effect():
-            container.status = "exited"
-
-        container.reload.side_effect = reload_side_effect
-
+        container.reload = Mock(side_effect=lambda: setattr(container, "status", "exited"))
         mock_docker_client.client.containers.get.return_value = container
 
-        # Get the stop function
-        _, _, _, _, _, stop_func = create_stop_container_tool(mock_docker_client)
-
-        # Execute with custom timeout
+        *_, stop_func = create_stop_container_tool(mock_docker_client)
         stop_func(container_id="abc123", timeout=30)
 
-        # Verify timeout was used
         container.stop.assert_called_once_with(timeout=30)
 
-    def test_stop_container_already_stopped(self, mock_docker_client):
+    @pytest.mark.parametrize("status", ["exited", "created"])
+    def test_stop_container_already_stopped(self, mock_docker_client, status):
         """Test stopping an already stopped container (idempotent)."""
-        # Mock container object
         container = Mock()
         container.id = "abc123"
-        container.status = "exited"
-
+        container.status = status
         mock_docker_client.client.containers.get.return_value = container
 
-        # Get the stop function
-        _, _, _, _, _, stop_func = create_stop_container_tool(mock_docker_client)
-
-        # Execute
+        *_, stop_func = create_stop_container_tool(mock_docker_client)
         result = stop_func(container_id="abc123")
 
-        # Verify - should return success without calling stop()
-        assert result["container_id"] == "abc123"
-        assert result["status"] == "exited"
-
-    def test_stop_container_created_status(self, mock_docker_client):
-        """Test stopping a container in created status (idempotent)."""
-        # Mock container object
-        container = Mock()
-        container.id = "abc123"
-        container.status = "created"
-
-        mock_docker_client.client.containers.get.return_value = container
-
-        # Get the stop function
-        _, _, _, _, _, stop_func = create_stop_container_tool(mock_docker_client)
-
-        # Execute
-        result = stop_func(container_id="abc123")
-
-        # Verify - should return success without calling stop()
-        assert result["container_id"] == "abc123"
-        assert result["status"] == "created"
-
-    def test_stop_container_not_found(self, mock_docker_client):
-        """Test stopping non-existent container."""
-        mock_docker_client.client.containers.get.side_effect = NotFound("Container not found")
-
-        # Get the stop function
-        _, _, _, _, _, stop_func = create_stop_container_tool(mock_docker_client)
-
-        # Execute and expect error
-        with pytest.raises(ContainerNotFound, match="Container not found"):
-            stop_func(container_id="nonexistent")
-
-    def test_stop_container_api_error(self, mock_docker_client):
-        """Test stopping container with API error."""
-        container = Mock()
-        container.status = "running"
-        container.stop.side_effect = APIError("Stop failed")
-
-        mock_docker_client.client.containers.get.return_value = container
-
-        # Get the stop function
-        _, _, _, _, _, stop_func = create_stop_container_tool(mock_docker_client)
-
-        # Execute and expect error
-        with pytest.raises(DockerOperationError, match="Failed to stop container"):
-            stop_func(container_id="abc123")
+        assert result["status"] == status
 
 
 class TestRestartContainerTool:
     """Test docker_restart_container tool."""
 
-    @pytest.fixture
-    def mock_docker_client(self):
-        """Create a mock Docker client."""
-        client = Mock(spec=DockerClientWrapper)
-        client.client = Mock()
-        client.client.containers = Mock()
-        return client
-
     def test_restart_container_success(self, mock_docker_client):
         """Test successfully restarting a container."""
-        # Mock container object
         container = Mock()
         container.id = "abc123"
         container.status = "running"
-        container.restart = Mock()
-        container.reload = Mock()
-
         mock_docker_client.client.containers.get.return_value = container
 
-        # Get the restart function
-        _, _, _, _, _, restart_func = create_restart_container_tool(mock_docker_client)
-
-        # Execute
+        *_, restart_func = create_restart_container_tool(mock_docker_client)
         result = restart_func(container_id="abc123")
 
-        # Verify
-        assert result["container_id"] == "abc123"
         assert result["status"] == "running"
         container.restart.assert_called_once_with(timeout=10)
-        container.reload.assert_called_once()
 
     def test_restart_container_with_custom_timeout(self, mock_docker_client):
         """Test restarting container with custom timeout."""
         container = Mock()
         container.id = "abc123"
         container.status = "running"
-        container.restart = Mock()
-        container.reload = Mock()
-
         mock_docker_client.client.containers.get.return_value = container
 
-        # Get the restart function
-        _, _, _, _, _, restart_func = create_restart_container_tool(mock_docker_client)
-
-        # Execute with custom timeout
+        *_, restart_func = create_restart_container_tool(mock_docker_client)
         restart_func(container_id="abc123", timeout=30)
 
-        # Verify timeout was used
         container.restart.assert_called_once_with(timeout=30)
-
-    def test_restart_container_not_found(self, mock_docker_client):
-        """Test restarting non-existent container."""
-        mock_docker_client.client.containers.get.side_effect = NotFound("Container not found")
-
-        # Get the restart function
-        _, _, _, _, _, restart_func = create_restart_container_tool(mock_docker_client)
-
-        # Execute and expect error
-        with pytest.raises(ContainerNotFound, match="Container not found"):
-            restart_func(container_id="nonexistent")
-
-    def test_restart_container_api_error(self, mock_docker_client):
-        """Test restarting container with API error."""
-        container = Mock()
-        container.restart.side_effect = APIError("Restart failed")
-
-        mock_docker_client.client.containers.get.return_value = container
-
-        # Get the restart function
-        _, _, _, _, _, restart_func = create_restart_container_tool(mock_docker_client)
-
-        # Execute and expect error
-        with pytest.raises(DockerOperationError, match="Failed to restart container"):
-            restart_func(container_id="abc123")
 
 
 class TestRemoveContainerTool:
     """Test docker_remove_container tool."""
 
-    @pytest.fixture
-    def mock_docker_client(self):
-        """Create a mock Docker client."""
-        client = Mock(spec=DockerClientWrapper)
-        client.client = Mock()
-        client.client.containers = Mock()
-        return client
-
     def test_remove_container_success(self, mock_docker_client):
         """Test successfully removing a container."""
-        # Mock container object
         container = Mock()
         container.id = "abc123"
-        container.remove = Mock()
-
         mock_docker_client.client.containers.get.return_value = container
 
-        # Get the remove function
-        _, _, _, _, _, remove_func = create_remove_container_tool(mock_docker_client)
-
-        # Execute
+        *_, remove_func = create_remove_container_tool(mock_docker_client)
         result = remove_func(container_id="abc123")
 
-        # Verify
         assert result["container_id"] == "abc123"
         assert result["removed_volumes"] is False
         container.remove.assert_called_once_with(force=False, v=False)
 
-    def test_remove_container_with_force(self, mock_docker_client):
-        """Test removing container with force flag."""
+    @pytest.mark.parametrize(
+        "kwargs,expected_call",
+        [
+            ({"force": True}, {"force": True, "v": False}),
+            ({"volumes": True}, {"force": False, "v": True}),
+            ({"force": True, "volumes": True}, {"force": True, "v": True}),
+        ],
+    )
+    def test_remove_container_with_options(self, mock_docker_client, kwargs, expected_call):
+        """Test removing container with various options."""
         container = Mock()
         container.id = "abc123"
-        container.remove = Mock()
-
         mock_docker_client.client.containers.get.return_value = container
 
-        # Get the remove function
-        _, _, _, _, _, remove_func = create_remove_container_tool(mock_docker_client)
+        *_, remove_func = create_remove_container_tool(mock_docker_client)
+        remove_func(container_id="abc123", **kwargs)
 
-        # Execute with force
-        remove_func(container_id="abc123", force=True)
-
-        # Verify force was used
-        container.remove.assert_called_once_with(force=True, v=False)
-
-    def test_remove_container_with_volumes(self, mock_docker_client):
-        """Test removing container with volumes."""
-        container = Mock()
-        container.id = "abc123"
-        container.remove = Mock()
-
-        mock_docker_client.client.containers.get.return_value = container
-
-        # Get the remove function
-        _, _, _, _, _, remove_func = create_remove_container_tool(mock_docker_client)
-
-        # Execute with volumes
-        result = remove_func(container_id="abc123", volumes=True)
-
-        # Verify volumes flag was used
-        assert result["removed_volumes"] is True
-        container.remove.assert_called_once_with(force=False, v=True)
-
-    def test_remove_container_with_force_and_volumes(self, mock_docker_client):
-        """Test removing container with both force and volumes."""
-        container = Mock()
-        container.id = "abc123"
-        container.remove = Mock()
-
-        mock_docker_client.client.containers.get.return_value = container
-
-        # Get the remove function
-        _, _, _, _, _, remove_func = create_remove_container_tool(mock_docker_client)
-
-        # Execute with force and volumes
-        remove_func(container_id="abc123", force=True, volumes=True)
-
-        # Verify both flags were used
-        container.remove.assert_called_once_with(force=True, v=True)
-
-    def test_remove_container_not_found(self, mock_docker_client):
-        """Test removing non-existent container."""
-        mock_docker_client.client.containers.get.side_effect = NotFound("Container not found")
-
-        # Get the remove function
-        _, _, _, _, _, remove_func = create_remove_container_tool(mock_docker_client)
-
-        # Execute and expect error
-        with pytest.raises(ContainerNotFound, match="Container not found"):
-            remove_func(container_id="nonexistent")
-
-    def test_remove_container_api_error(self, mock_docker_client):
-        """Test removing container with API error."""
-        container = Mock()
-        container.id = "abc123"
-        container.remove.side_effect = APIError("Remove failed")
-
-        mock_docker_client.client.containers.get.return_value = container
-
-        # Get the remove function
-        _, _, _, _, _, remove_func = create_remove_container_tool(mock_docker_client)
-
-        # Execute and expect error
-        with pytest.raises(DockerOperationError, match="Failed to remove container"):
-            remove_func(container_id="abc123")
+        container.remove.assert_called_once_with(**expected_call)

--- a/tests/unit/test_fastmcp_tools_network.py
+++ b/tests/unit/test_fastmcp_tools_network.py
@@ -24,111 +24,130 @@ from mcp_docker.utils.errors import (
 )
 
 
+# Module-level fixtures to avoid duplication across test classes
+@pytest.fixture
+def mock_docker_client():
+    """Create a mock Docker client."""
+    client = Mock(spec=DockerClientWrapper)
+    client.client = Mock()
+    client.client.networks = Mock()
+    client.client.containers = Mock()
+    return client
+
+
+@pytest.fixture
+def safety_config():
+    """Create safety config."""
+    return SafetyConfig()
+
+
 class TestBuildConnectKwargs:
     """Test _build_connect_kwargs helper function."""
 
-    def test_build_minimal_kwargs(self):
-        """Test building kwargs with only container_id."""
-        kwargs = _build_connect_kwargs(
-            container_id="abc123",
-            aliases=None,
-            ipv4_address=None,
-            ipv6_address=None,
-            links=None,
-        )
-        assert kwargs == {"container": "abc123"}
-
-    def test_build_with_aliases(self):
-        """Test building kwargs with aliases."""
-        kwargs = _build_connect_kwargs(
-            container_id="abc123",
-            aliases=["web", "frontend"],
-            ipv4_address=None,
-            ipv6_address=None,
-            links=None,
-        )
-        assert kwargs == {"container": "abc123", "aliases": ["web", "frontend"]}
-
-    def test_build_with_ipv4_address(self):
-        """Test building kwargs with IPv4 address."""
-        kwargs = _build_connect_kwargs(
-            container_id="abc123",
-            aliases=None,
-            ipv4_address="172.20.0.5",
-            ipv6_address=None,
-            links=None,
-        )
-        assert kwargs == {"container": "abc123", "ipv4_address": "172.20.0.5"}
-
-    def test_build_with_ipv6_address(self):
-        """Test building kwargs with IPv6 address."""
-        kwargs = _build_connect_kwargs(
-            container_id="abc123",
-            aliases=None,
-            ipv4_address=None,
-            ipv6_address="2001:db8::1",
-            links=None,
-        )
-        assert kwargs == {"container": "abc123", "ipv6_address": "2001:db8::1"}
-
-    def test_build_with_links(self):
-        """Test building kwargs with links."""
-        kwargs = _build_connect_kwargs(
-            container_id="abc123",
-            aliases=None,
-            ipv4_address=None,
-            ipv6_address=None,
-            links=["db:database"],
-        )
-        assert kwargs == {"container": "abc123", "links": ["db:database"]}
-
-    def test_build_with_all_options(self):
-        """Test building kwargs with all options."""
-        kwargs = _build_connect_kwargs(
-            container_id="abc123",
-            aliases=["web", "api"],
-            ipv4_address="172.20.0.5",
-            ipv6_address="2001:db8::1",
-            links=["db:database"],
-        )
-        assert kwargs == {
-            "container": "abc123",
-            "aliases": ["web", "api"],
-            "ipv4_address": "172.20.0.5",
-            "ipv6_address": "2001:db8::1",
-            "links": ["db:database"],
-        }
+    @pytest.mark.parametrize(
+        "kwargs,expected",
+        [
+            (
+                {
+                    "container_id": "abc123",
+                    "aliases": None,
+                    "ipv4_address": None,
+                    "ipv6_address": None,
+                    "links": None,
+                },
+                {"container": "abc123"},
+            ),
+            (
+                {
+                    "container_id": "abc123",
+                    "aliases": ["web", "frontend"],
+                    "ipv4_address": None,
+                    "ipv6_address": None,
+                    "links": None,
+                },
+                {"container": "abc123", "aliases": ["web", "frontend"]},
+            ),
+            (
+                {
+                    "container_id": "abc123",
+                    "aliases": None,
+                    "ipv4_address": "172.20.0.5",
+                    "ipv6_address": None,
+                    "links": None,
+                },
+                {"container": "abc123", "ipv4_address": "172.20.0.5"},
+            ),
+            (
+                {
+                    "container_id": "abc123",
+                    "aliases": None,
+                    "ipv4_address": None,
+                    "ipv6_address": "2001:db8::1",
+                    "links": None,
+                },
+                {"container": "abc123", "ipv6_address": "2001:db8::1"},
+            ),
+            (
+                {
+                    "container_id": "abc123",
+                    "aliases": None,
+                    "ipv4_address": None,
+                    "ipv6_address": None,
+                    "links": ["db:database"],
+                },
+                {"container": "abc123", "links": ["db:database"]},
+            ),
+            (
+                {
+                    "container_id": "abc123",
+                    "aliases": ["web", "api"],
+                    "ipv4_address": "172.20.0.5",
+                    "ipv6_address": "2001:db8::1",
+                    "links": ["db:database"],
+                },
+                {
+                    "container": "abc123",
+                    "aliases": ["web", "api"],
+                    "ipv4_address": "172.20.0.5",
+                    "ipv6_address": "2001:db8::1",
+                    "links": ["db:database"],
+                },
+            ),
+        ],
+    )
+    def test_build_connect_kwargs(self, kwargs, expected):
+        """Test building kwargs with various combinations."""
+        result = _build_connect_kwargs(**kwargs)
+        assert result == expected
 
 
 class TestCreateNetworkInputValidation:
     """Test CreateNetworkInput Pydantic model validation."""
 
-    def test_json_string_parsing_options(self):
-        """Test that options JSON string is parsed correctly."""
-        input_data = CreateNetworkInput(
-            name="my-network",
-            options='{"com.docker.network.bridge.name": "docker1", "mtu": "1500"}',
-        )
-        assert input_data.options == {
-            "com.docker.network.bridge.name": "docker1",
-            "mtu": "1500",
-        }
-
-    def test_json_string_parsing_ipam(self):
-        """Test that ipam JSON string is parsed correctly."""
-        input_data = CreateNetworkInput(
-            name="my-network",
-            ipam='{"Config": [{"Subnet": "172.20.0.0/16", "Gateway": "172.20.0.1"}]}',
-        )
-        assert input_data.ipam == {"Config": [{"Subnet": "172.20.0.0/16", "Gateway": "172.20.0.1"}]}
-
-    def test_json_string_parsing_labels(self):
-        """Test that labels JSON string is parsed correctly."""
-        input_data = CreateNetworkInput(
-            name="my-network",
-            labels='{"environment": "production", "team": "backend"}',
-        )
-        assert input_data.labels == {"environment": "production", "team": "backend"}
+    @pytest.mark.parametrize(
+        "field,json_value,expected",
+        [
+            (
+                "options",
+                '{"com.docker.network.bridge.name": "docker1", "mtu": "1500"}',
+                {"com.docker.network.bridge.name": "docker1", "mtu": "1500"},
+            ),
+            (
+                "ipam",
+                '{"Config": [{"Subnet": "172.20.0.0/16", "Gateway": "172.20.0.1"}]}',
+                {"Config": [{"Subnet": "172.20.0.0/16", "Gateway": "172.20.0.1"}]},
+            ),
+            (
+                "labels",
+                '{"environment": "production", "team": "backend"}',
+                {"environment": "production", "team": "backend"},
+            ),
+        ],
+    )
+    def test_json_string_parsing(self, field, json_value, expected):
+        """Test that JSON strings are parsed correctly."""
+        input_data = CreateNetworkInput(name="my-network", **{field: json_value})
+        assert getattr(input_data, field) == expected
 
     def test_dict_passthrough(self):
         """Test that dict values are passed through."""
@@ -143,25 +162,133 @@ class TestCreateNetworkInputValidation:
         assert input_data.labels == {"env": "prod"}
 
 
+class TestNetworkNotFoundErrors:
+    """Test network not found error handling across tools."""
+
+    @pytest.mark.parametrize(
+        "tool_creator,call_kwargs",
+        [
+            (create_inspect_network_tool, {"network_id": "nonexistent"}),
+            (create_remove_network_tool, {"network_id": "nonexistent"}),
+            (
+                create_connect_container_tool,
+                {"network_id": "nonexistent", "container_id": "con123"},
+            ),
+            (
+                create_disconnect_container_tool,
+                {"network_id": "nonexistent", "container_id": "con123"},
+            ),
+        ],
+    )
+    def test_network_not_found(self, mock_docker_client, tool_creator, call_kwargs):
+        """Test that NetworkNotFound is raised when network doesn't exist."""
+        mock_docker_client.client.networks.get.side_effect = NotFound("network not found")
+
+        *_, func = tool_creator(mock_docker_client)
+
+        with pytest.raises(NetworkNotFound, match="Network not found"):
+            func(**call_kwargs)
+
+
+class TestAPIErrors:
+    """Test API error handling across tools."""
+
+    @pytest.mark.parametrize(
+        "tool_creator,needs_safety_config,call_kwargs,error_match,setup_error_on",
+        [
+            (create_list_networks_tool, True, {}, "Failed to list networks", "networks.list"),
+            (
+                create_inspect_network_tool,
+                False,
+                {"network_id": "test"},
+                "Failed to inspect network",
+                "networks.get",
+            ),
+            (
+                create_create_network_tool,
+                False,
+                {"name": "test"},
+                "Failed to create network",
+                "networks.create",
+            ),
+        ],
+    )
+    def test_api_error(  # noqa: PLR0913
+        self,
+        mock_docker_client,
+        safety_config,
+        tool_creator,
+        needs_safety_config,
+        call_kwargs,
+        error_match,
+        setup_error_on,
+    ):
+        """Test that DockerOperationError is raised on API errors."""
+        method_mapping = {
+            "networks.list": mock_docker_client.client.networks.list,
+            "networks.get": mock_docker_client.client.networks.get,
+            "networks.create": mock_docker_client.client.networks.create,
+        }
+        method_mapping[setup_error_on].side_effect = APIError("API failed")
+
+        if needs_safety_config:
+            *_, func = tool_creator(mock_docker_client, safety_config)
+        else:
+            *_, func = tool_creator(mock_docker_client)
+
+        with pytest.raises(DockerOperationError, match=error_match):
+            func(**call_kwargs)
+
+    def test_remove_network_api_error(self, mock_docker_client):
+        """Test removing network with API error."""
+        network = Mock()
+        network.id = "net123"
+        network.remove.side_effect = APIError("Remove failed")
+        mock_docker_client.client.networks.get.return_value = network
+
+        *_, remove_func = create_remove_network_tool(mock_docker_client)
+
+        with pytest.raises(DockerOperationError, match="Failed to remove network"):
+            remove_func(network_id="net123")
+
+    def test_connect_container_api_error(self, mock_docker_client):
+        """Test connecting container with API error."""
+        network = Mock()
+        network.attrs = {"Containers": {}}
+        network.connect = Mock(side_effect=APIError("Connect failed"))
+        container = Mock()
+        container.id = "con123"
+
+        mock_docker_client.client.networks.get.return_value = network
+        mock_docker_client.client.containers.get.return_value = container
+
+        *_, connect_func = create_connect_container_tool(mock_docker_client)
+
+        with pytest.raises(DockerOperationError, match="Failed to connect container"):
+            connect_func(network_id="net123", container_id="con123")
+
+    def test_disconnect_container_api_error(self, mock_docker_client):
+        """Test disconnecting container with API error."""
+        network = Mock()
+        network.attrs = {"Containers": {"con123": {}}}
+        network.disconnect = Mock(side_effect=APIError("Disconnect failed"))
+        container = Mock()
+        container.id = "con123"
+
+        mock_docker_client.client.networks.get.return_value = network
+        mock_docker_client.client.containers.get.return_value = container
+
+        *_, disconnect_func = create_disconnect_container_tool(mock_docker_client)
+
+        with pytest.raises(DockerOperationError, match="Failed to disconnect container"):
+            disconnect_func(network_id="net123", container_id="con123")
+
+
 class TestListNetworksTool:
     """Test docker_list_networks tool."""
 
-    @pytest.fixture
-    def mock_docker_client(self):
-        """Create a mock Docker client."""
-        client = Mock(spec=DockerClientWrapper)
-        client.client = Mock()
-        client.client.networks = Mock()
-        return client
-
-    @pytest.fixture
-    def safety_config(self):
-        """Create safety config."""
-        return SafetyConfig()
-
     def test_list_networks_success(self, mock_docker_client, safety_config):
         """Test successful network listing."""
-        # Mock network objects
         net1 = Mock()
         net1.id = "net1id"
         net1.short_id = "net1"
@@ -176,13 +303,9 @@ class TestListNetworksTool:
 
         mock_docker_client.client.networks.list.return_value = [net1, net2]
 
-        # Get the list function
-        _, _, _, _, _, list_func = create_list_networks_tool(mock_docker_client, safety_config)
-
-        # Execute
+        *_, list_func = create_list_networks_tool(mock_docker_client, safety_config)
         result = list_func()
 
-        # Verify
         assert result["count"] == 2
         assert len(result["networks"]) == 2
         assert result["networks"][0]["name"] == "bridge"
@@ -193,23 +316,17 @@ class TestListNetworksTool:
         """Test network listing with filters."""
         mock_docker_client.client.networks.list.return_value = []
 
-        # Get the list function
-        _, _, _, _, _, list_func = create_list_networks_tool(mock_docker_client, safety_config)
-
-        # Execute with filters
+        *_, list_func = create_list_networks_tool(mock_docker_client, safety_config)
         filters = {"driver": ["bridge"]}
         result = list_func(filters=filters)
 
-        # Verify filters were passed
         mock_docker_client.client.networks.list.assert_called_once_with(filters=filters)
         assert result["count"] == 0
 
     def test_list_networks_with_truncation(self, mock_docker_client):
         """Test network listing with output truncation."""
-        # Create safety config with limit
         safety_config = SafetyConfig(max_list_results=1)
 
-        # Mock multiple networks
         net1 = Mock()
         net1.id = "net1id"
         net1.short_id = "net1"
@@ -224,44 +341,20 @@ class TestListNetworksTool:
 
         mock_docker_client.client.networks.list.return_value = [net1, net2]
 
-        # Get the list function
-        _, _, _, _, _, list_func = create_list_networks_tool(mock_docker_client, safety_config)
-
-        # Execute
+        *_, list_func = create_list_networks_tool(mock_docker_client, safety_config)
         result = list_func()
 
-        # Verify truncation
-        assert result["count"] == 2  # Original count
-        assert len(result["networks"]) == 1  # Truncated to 1
+        assert result["count"] == 2
+        assert len(result["networks"]) == 1
         assert result["truncation_info"]["truncated"] is True
         assert "message" in result["truncation_info"]
-
-    def test_list_networks_api_error(self, mock_docker_client, safety_config):
-        """Test network listing with API error."""
-        mock_docker_client.client.networks.list.side_effect = APIError("List failed")
-
-        # Get the list function
-        _, _, _, _, _, list_func = create_list_networks_tool(mock_docker_client, safety_config)
-
-        # Execute and expect error
-        with pytest.raises(DockerOperationError, match="Failed to list networks"):
-            list_func()
 
 
 class TestInspectNetworkTool:
     """Test docker_inspect_network tool."""
 
-    @pytest.fixture
-    def mock_docker_client(self):
-        """Create a mock Docker client."""
-        client = Mock(spec=DockerClientWrapper)
-        client.client = Mock()
-        client.client.networks = Mock()
-        return client
-
     def test_inspect_network_success(self, mock_docker_client):
         """Test successful network inspection."""
-        # Mock network object
         network = Mock()
         network.attrs = {
             "Name": "my-network",
@@ -270,214 +363,72 @@ class TestInspectNetworkTool:
             "Scope": "local",
             "IPAM": {"Config": [{"Subnet": "172.20.0.0/16"}]},
         }
-
         mock_docker_client.client.networks.get.return_value = network
 
-        # Get the inspect function
-        _, _, _, _, _, inspect_func = create_inspect_network_tool(mock_docker_client)
-
-        # Execute
+        *_, inspect_func = create_inspect_network_tool(mock_docker_client)
         result = inspect_func(network_id="my-network")
 
-        # Verify
         assert result["details"]["Name"] == "my-network"
         assert result["details"]["Driver"] == "bridge"
         mock_docker_client.client.networks.get.assert_called_once_with("my-network")
-
-    def test_inspect_network_not_found(self, mock_docker_client):
-        """Test inspecting non-existent network."""
-        mock_docker_client.client.networks.get.side_effect = NotFound("Network not found")
-
-        # Get the inspect function
-        _, _, _, _, _, inspect_func = create_inspect_network_tool(mock_docker_client)
-
-        # Execute and expect error
-        with pytest.raises(NetworkNotFound, match="Network not found"):
-            inspect_func(network_id="nonexistent")
-
-    def test_inspect_network_api_error(self, mock_docker_client):
-        """Test network inspection with API error."""
-        mock_docker_client.client.networks.get.side_effect = APIError("Inspect failed")
-
-        # Get the inspect function
-        _, _, _, _, _, inspect_func = create_inspect_network_tool(mock_docker_client)
-
-        # Execute and expect error
-        with pytest.raises(DockerOperationError, match="Failed to inspect network"):
-            inspect_func(network_id="my-network")
 
 
 class TestCreateNetworkTool:
     """Test docker_create_network tool."""
 
-    @pytest.fixture
-    def mock_docker_client(self):
-        """Create a mock Docker client."""
-        client = Mock(spec=DockerClientWrapper)
-        client.client = Mock()
-        client.client.networks = Mock()
-        return client
-
     def test_create_network_minimal(self, mock_docker_client):
         """Test creating network with minimal parameters."""
-        # Mock network object
         network = Mock()
         network.id = "abc123"
         network.name = "my-network"
-
         mock_docker_client.client.networks.create.return_value = network
 
-        # Get the create function
-        _, _, _, _, _, create_func = create_create_network_tool(mock_docker_client)
-
-        # Execute
+        *_, create_func = create_create_network_tool(mock_docker_client)
         result = create_func(name="my-network")
 
-        # Verify
         assert result["network_id"] == "abc123"
         assert result["name"] == "my-network"
         assert result["warnings"] is None
         mock_docker_client.client.networks.create.assert_called_once()
 
-    def test_create_network_with_driver(self, mock_docker_client):
-        """Test creating network with custom driver."""
-        network = Mock()
-        network.id = "abc123"
-        network.name = "my-overlay"
-
-        mock_docker_client.client.networks.create.return_value = network
-
-        # Get the create function
-        _, _, _, _, _, create_func = create_create_network_tool(mock_docker_client)
-
-        # Execute
-        create_func(name="my-overlay", driver="overlay")
-
-        # Verify
-        call_kwargs = mock_docker_client.client.networks.create.call_args.kwargs
-        assert call_kwargs["driver"] == "overlay"
-
-    def test_create_network_with_options(self, mock_docker_client):
-        """Test creating network with options."""
+    @pytest.mark.parametrize(
+        "extra_kwargs,expected_kwarg",
+        [
+            ({"driver": "overlay"}, ("driver", "overlay")),
+            ({"options": {"mtu": "1500"}}, ("options", {"mtu": "1500"})),
+            (
+                {"ipam": {"Config": [{"Subnet": "172.20.0.0/16"}]}},
+                ("ipam", {"Config": [{"Subnet": "172.20.0.0/16"}]}),
+            ),
+            ({"labels": {"env": "prod"}}, ("labels", {"env": "prod"})),
+            ({"internal": True}, ("internal", True)),
+            ({"enable_ipv6": True}, ("enable_ipv6", True)),
+            ({"attachable": True}, ("attachable", True)),
+        ],
+    )
+    def test_create_network_with_options(self, mock_docker_client, extra_kwargs, expected_kwarg):
+        """Test creating network with various options."""
         network = Mock()
         network.id = "abc123"
         network.name = "my-network"
-
         mock_docker_client.client.networks.create.return_value = network
 
-        # Get the create function
-        _, _, _, _, _, create_func = create_create_network_tool(mock_docker_client)
+        *_, create_func = create_create_network_tool(mock_docker_client)
+        create_func(name="my-network", **extra_kwargs)
 
-        # Execute
-        options = {"com.docker.network.bridge.name": "docker1", "mtu": "1500"}
-        create_func(name="my-network", options=options)
-
-        # Verify
         call_kwargs = mock_docker_client.client.networks.create.call_args.kwargs
-        assert call_kwargs["options"] == options
-
-    def test_create_network_with_ipam(self, mock_docker_client):
-        """Test creating network with IPAM configuration."""
-        network = Mock()
-        network.id = "abc123"
-        network.name = "my-network"
-
-        mock_docker_client.client.networks.create.return_value = network
-
-        # Get the create function
-        _, _, _, _, _, create_func = create_create_network_tool(mock_docker_client)
-
-        # Execute
-        ipam = {"Config": [{"Subnet": "172.20.0.0/16", "Gateway": "172.20.0.1"}]}
-        create_func(name="my-network", ipam=ipam)
-
-        # Verify
-        call_kwargs = mock_docker_client.client.networks.create.call_args.kwargs
-        assert call_kwargs["ipam"] == ipam
-
-    def test_create_network_with_labels(self, mock_docker_client):
-        """Test creating network with labels."""
-        network = Mock()
-        network.id = "abc123"
-        network.name = "my-network"
-
-        mock_docker_client.client.networks.create.return_value = network
-
-        # Get the create function
-        _, _, _, _, _, create_func = create_create_network_tool(mock_docker_client)
-
-        # Execute
-        labels = {"environment": "production", "team": "backend"}
-        create_func(name="my-network", labels=labels)
-
-        # Verify
-        call_kwargs = mock_docker_client.client.networks.create.call_args.kwargs
-        assert call_kwargs["labels"] == labels
-
-    def test_create_network_with_all_options(self, mock_docker_client):
-        """Test creating network with all options."""
-        network = Mock()
-        network.id = "abc123"
-        network.name = "my-network"
-
-        mock_docker_client.client.networks.create.return_value = network
-
-        # Get the create function
-        _, _, _, _, _, create_func = create_create_network_tool(mock_docker_client)
-
-        # Execute with all options
-        create_func(
-            name="my-network",
-            driver="bridge",
-            options={"mtu": "1500"},
-            ipam={"Config": [{"Subnet": "172.20.0.0/16"}]},
-            internal=True,
-            labels={"env": "prod"},
-            enable_ipv6=True,
-            attachable=True,
-        )
-
-        # Verify all options were passed
-        call_kwargs = mock_docker_client.client.networks.create.call_args.kwargs
-        assert call_kwargs["name"] == "my-network"
-        assert call_kwargs["driver"] == "bridge"
-        assert call_kwargs["options"] == {"mtu": "1500"}
-        assert call_kwargs["ipam"] == {"Config": [{"Subnet": "172.20.0.0/16"}]}
-        assert call_kwargs["internal"] is True
-        assert call_kwargs["labels"] == {"env": "prod"}
-        assert call_kwargs["enable_ipv6"] is True
-        assert call_kwargs["attachable"] is True
-
-    def test_create_network_api_error(self, mock_docker_client):
-        """Test network creation with API error."""
-        mock_docker_client.client.networks.create.side_effect = APIError("Create failed")
-
-        # Get the create function
-        _, _, _, _, _, create_func = create_create_network_tool(mock_docker_client)
-
-        # Execute and expect error
-        with pytest.raises(DockerOperationError, match="Failed to create network"):
-            create_func(name="my-network")
+        key, value = expected_kwarg
+        assert call_kwargs[key] == value
 
 
 class TestConnectContainerTool:
     """Test docker_connect_container tool."""
 
-    @pytest.fixture
-    def mock_docker_client(self):
-        """Create a mock Docker client."""
-        client = Mock(spec=DockerClientWrapper)
-        client.client = Mock()
-        client.client.networks = Mock()
-        client.client.containers = Mock()
-        return client
-
     def test_connect_container_success(self, mock_docker_client):
         """Test successfully connecting container to network."""
-        # Mock network and container objects
         network = Mock()
         network.id = "net123"
-        network.attrs = {"Containers": {}}  # Not connected
+        network.attrs = {"Containers": {}}
         network.connect = Mock()
 
         container = Mock()
@@ -486,13 +437,9 @@ class TestConnectContainerTool:
         mock_docker_client.client.networks.get.return_value = network
         mock_docker_client.client.containers.get.return_value = container
 
-        # Get the connect function
-        _, _, _, _, _, connect_func = create_connect_container_tool(mock_docker_client)
-
-        # Execute
+        *_, connect_func = create_connect_container_tool(mock_docker_client)
         result = connect_func(network_id="net123", container_id="con123")
 
-        # Verify
         assert result["network_id"] == "net123"
         assert result["container_id"] == "con123"
         assert result["status"] == "connected"
@@ -500,10 +447,9 @@ class TestConnectContainerTool:
 
     def test_connect_container_already_connected(self, mock_docker_client):
         """Test connecting already connected container (idempotent)."""
-        # Mock network and container objects
         network = Mock()
         network.id = "net123"
-        network.attrs = {"Containers": {"con123": {}}}  # Already connected
+        network.attrs = {"Containers": {"con123": {}}}
 
         container = Mock()
         container.id = "con123"
@@ -511,17 +457,30 @@ class TestConnectContainerTool:
         mock_docker_client.client.networks.get.return_value = network
         mock_docker_client.client.containers.get.return_value = container
 
-        # Get the connect function
-        _, _, _, _, _, connect_func = create_connect_container_tool(mock_docker_client)
-
-        # Execute
+        *_, connect_func = create_connect_container_tool(mock_docker_client)
         result = connect_func(network_id="net123", container_id="con123")
 
-        # Verify - should return success without calling connect()
         assert result["status"] == "connected"
 
-    def test_connect_container_with_aliases(self, mock_docker_client):
-        """Test connecting container with aliases."""
+    @pytest.mark.parametrize(
+        "extra_kwargs,expected_connect_kwargs",
+        [
+            ({"aliases": ["web", "api"]}, {"container": "con123", "aliases": ["web", "api"]}),
+            (
+                {"ipv4_address": "172.20.0.5", "ipv6_address": "2001:db8::1"},
+                {
+                    "container": "con123",
+                    "ipv4_address": "172.20.0.5",
+                    "ipv6_address": "2001:db8::1",
+                },
+            ),
+            ({"links": ["db:database"]}, {"container": "con123", "links": ["db:database"]}),
+        ],
+    )
+    def test_connect_container_with_options(
+        self, mock_docker_client, extra_kwargs, expected_connect_kwargs
+    ):
+        """Test connecting container with various options."""
         network = Mock()
         network.id = "net123"
         network.attrs = {"Containers": {}}
@@ -533,88 +492,10 @@ class TestConnectContainerTool:
         mock_docker_client.client.networks.get.return_value = network
         mock_docker_client.client.containers.get.return_value = container
 
-        # Get the connect function
-        _, _, _, _, _, connect_func = create_connect_container_tool(mock_docker_client)
+        *_, connect_func = create_connect_container_tool(mock_docker_client)
+        connect_func(network_id="net123", container_id="con123", **extra_kwargs)
 
-        # Execute with aliases
-        connect_func(network_id="net123", container_id="con123", aliases=["web", "api"])
-
-        # Verify aliases were passed
-        network.connect.assert_called_once_with(
-            container="con123",
-            aliases=["web", "api"],
-        )
-
-    def test_connect_container_with_ip_addresses(self, mock_docker_client):
-        """Test connecting container with IP addresses."""
-        network = Mock()
-        network.id = "net123"
-        network.attrs = {"Containers": {}}
-        network.connect = Mock()
-
-        container = Mock()
-        container.id = "con123"
-
-        mock_docker_client.client.networks.get.return_value = network
-        mock_docker_client.client.containers.get.return_value = container
-
-        # Get the connect function
-        _, _, _, _, _, connect_func = create_connect_container_tool(mock_docker_client)
-
-        # Execute with IP addresses
-        connect_func(
-            network_id="net123",
-            container_id="con123",
-            ipv4_address="172.20.0.5",
-            ipv6_address="2001:db8::1",
-        )
-
-        # Verify IP addresses were passed
-        network.connect.assert_called_once_with(
-            container="con123",
-            ipv4_address="172.20.0.5",
-            ipv6_address="2001:db8::1",
-        )
-
-    def test_connect_container_with_links(self, mock_docker_client):
-        """Test connecting container with links."""
-        network = Mock()
-        network.id = "net123"
-        network.attrs = {"Containers": {}}
-        network.connect = Mock()
-
-        container = Mock()
-        container.id = "con123"
-
-        mock_docker_client.client.networks.get.return_value = network
-        mock_docker_client.client.containers.get.return_value = container
-
-        # Get the connect function
-        _, _, _, _, _, connect_func = create_connect_container_tool(mock_docker_client)
-
-        # Execute with links
-        connect_func(
-            network_id="net123",
-            container_id="con123",
-            links=["db:database"],
-        )
-
-        # Verify links were passed
-        network.connect.assert_called_once_with(
-            container="con123",
-            links=["db:database"],
-        )
-
-    def test_connect_container_network_not_found(self, mock_docker_client):
-        """Test connecting to non-existent network."""
-        mock_docker_client.client.networks.get.side_effect = NotFound("network not found")
-
-        # Get the connect function
-        _, _, _, _, _, connect_func = create_connect_container_tool(mock_docker_client)
-
-        # Execute and expect error
-        with pytest.raises(NetworkNotFound, match="Network not found"):
-            connect_func(network_id="nonexistent", container_id="con123")
+        network.connect.assert_called_once_with(**expected_connect_kwargs)
 
     def test_connect_container_container_not_found(self, mock_docker_client):
         """Test connecting non-existent container."""
@@ -625,51 +506,20 @@ class TestConnectContainerTool:
         mock_docker_client.client.networks.get.return_value = network
         mock_docker_client.client.containers.get.side_effect = NotFound("container not found")
 
-        # Get the connect function
-        _, _, _, _, _, connect_func = create_connect_container_tool(mock_docker_client)
+        *_, connect_func = create_connect_container_tool(mock_docker_client)
 
-        # Execute and expect error
         with pytest.raises(ContainerNotFound, match="Container not found"):
             connect_func(network_id="net123", container_id="nonexistent")
-
-    def test_connect_container_api_error(self, mock_docker_client):
-        """Test connecting container with API error."""
-        network = Mock()
-        network.attrs = {"Containers": {}}
-        network.connect = Mock(side_effect=APIError("Connect failed"))
-
-        container = Mock()
-        container.id = "con123"
-
-        mock_docker_client.client.networks.get.return_value = network
-        mock_docker_client.client.containers.get.return_value = container
-
-        # Get the connect function
-        _, _, _, _, _, connect_func = create_connect_container_tool(mock_docker_client)
-
-        # Execute and expect error
-        with pytest.raises(DockerOperationError, match="Failed to connect container"):
-            connect_func(network_id="net123", container_id="con123")
 
 
 class TestDisconnectContainerTool:
     """Test docker_disconnect_container tool."""
 
-    @pytest.fixture
-    def mock_docker_client(self):
-        """Create a mock Docker client."""
-        client = Mock(spec=DockerClientWrapper)
-        client.client = Mock()
-        client.client.networks = Mock()
-        client.client.containers = Mock()
-        return client
-
     def test_disconnect_container_success(self, mock_docker_client):
         """Test successfully disconnecting container from network."""
-        # Mock network and container objects
         network = Mock()
         network.id = "net123"
-        network.attrs = {"Containers": {"con123": {}}}  # Connected
+        network.attrs = {"Containers": {"con123": {}}}
         network.disconnect = Mock()
 
         container = Mock()
@@ -678,13 +528,9 @@ class TestDisconnectContainerTool:
         mock_docker_client.client.networks.get.return_value = network
         mock_docker_client.client.containers.get.return_value = container
 
-        # Get the disconnect function
-        _, _, _, _, _, disconnect_func = create_disconnect_container_tool(mock_docker_client)
-
-        # Execute
+        *_, disconnect_func = create_disconnect_container_tool(mock_docker_client)
         result = disconnect_func(network_id="net123", container_id="con123")
 
-        # Verify
         assert result["network_id"] == "net123"
         assert result["container_id"] == "con123"
         assert result["status"] == "disconnected"
@@ -692,10 +538,9 @@ class TestDisconnectContainerTool:
 
     def test_disconnect_container_already_disconnected(self, mock_docker_client):
         """Test disconnecting already disconnected container (idempotent)."""
-        # Mock network and container objects
         network = Mock()
         network.id = "net123"
-        network.attrs = {"Containers": {}}  # Not connected
+        network.attrs = {"Containers": {}}
 
         container = Mock()
         container.id = "con123"
@@ -703,13 +548,9 @@ class TestDisconnectContainerTool:
         mock_docker_client.client.networks.get.return_value = network
         mock_docker_client.client.containers.get.return_value = container
 
-        # Get the disconnect function
-        _, _, _, _, _, disconnect_func = create_disconnect_container_tool(mock_docker_client)
-
-        # Execute
+        *_, disconnect_func = create_disconnect_container_tool(mock_docker_client)
         result = disconnect_func(network_id="net123", container_id="con123")
 
-        # Verify - should return success without calling disconnect()
         assert result["status"] == "disconnected"
 
     def test_disconnect_container_with_force(self, mock_docker_client):
@@ -725,53 +566,30 @@ class TestDisconnectContainerTool:
         mock_docker_client.client.networks.get.return_value = network
         mock_docker_client.client.containers.get.return_value = container
 
-        # Get the disconnect function
-        _, _, _, _, _, disconnect_func = create_disconnect_container_tool(mock_docker_client)
-
-        # Execute with force
+        *_, disconnect_func = create_disconnect_container_tool(mock_docker_client)
         disconnect_func(network_id="net123", container_id="con123", force=True)
 
-        # Verify force was used
         network.disconnect.assert_called_once_with(container="con123", force=True)
 
-    def test_disconnect_container_network_not_found(self, mock_docker_client):
-        """Test disconnecting from non-existent network."""
-        mock_docker_client.client.networks.get.side_effect = NotFound("network not found")
-
-        # Get the disconnect function
-        _, _, _, _, _, disconnect_func = create_disconnect_container_tool(mock_docker_client)
-
-        # Execute and expect error
-        with pytest.raises(NetworkNotFound, match="Network not found"):
-            disconnect_func(network_id="nonexistent", container_id="con123")
-
-    def test_disconnect_container_container_not_found_idempotent(self, mock_docker_client):
+    def test_disconnect_container_not_found_idempotent(self, mock_docker_client):
         """Test disconnecting non-existent container (idempotent behavior)."""
-        # When container doesn't exist, it won't be in network's Containers
-        # The function treats this as "already disconnected" (idempotent)
         network = Mock()
         network.id = "net123"
-        network.attrs = {"Containers": {}}  # Container not in network
+        network.attrs = {"Containers": {}}
 
         mock_docker_client.client.networks.get.return_value = network
         mock_docker_client.client.containers.get.side_effect = NotFound("container not found")
 
-        # Get the disconnect function
-        _, _, _, _, _, disconnect_func = create_disconnect_container_tool(mock_docker_client)
-
-        # Execute - should return success (idempotent)
+        *_, disconnect_func = create_disconnect_container_tool(mock_docker_client)
         result = disconnect_func(network_id="net123", container_id="nonexistent")
 
-        # Verify - returns disconnected status without error
         assert result["status"] == "disconnected"
 
     def test_disconnect_container_not_found_during_disconnect(self, mock_docker_client):
         """Test when container not found error occurs during disconnect operation."""
-        # This tests the case where disconnect() raises NotFound with container error
         network = Mock()
         network.id = "net123"
-        network.attrs = {"Containers": {"con123": {}}}  # Container appears connected
-        # Raise NotFound with message that doesn't contain "network"
+        network.attrs = {"Containers": {"con123": {}}}
         network.disconnect = Mock(side_effect=NotFound("container con123 not found"))
 
         container = Mock()
@@ -780,85 +598,24 @@ class TestDisconnectContainerTool:
         mock_docker_client.client.networks.get.return_value = network
         mock_docker_client.client.containers.get.return_value = container
 
-        # Get the disconnect function
-        _, _, _, _, _, disconnect_func = create_disconnect_container_tool(mock_docker_client)
+        *_, disconnect_func = create_disconnect_container_tool(mock_docker_client)
 
-        # Execute and expect ContainerNotFound error
         with pytest.raises(ContainerNotFound, match="Container not found"):
-            disconnect_func(network_id="net123", container_id="con123")
-
-    def test_disconnect_container_api_error(self, mock_docker_client):
-        """Test disconnecting container with API error."""
-        network = Mock()
-        network.attrs = {"Containers": {"con123": {}}}
-        network.disconnect = Mock(side_effect=APIError("Disconnect failed"))
-
-        container = Mock()
-        container.id = "con123"
-
-        mock_docker_client.client.networks.get.return_value = network
-        mock_docker_client.client.containers.get.return_value = container
-
-        # Get the disconnect function
-        _, _, _, _, _, disconnect_func = create_disconnect_container_tool(mock_docker_client)
-
-        # Execute and expect error
-        with pytest.raises(DockerOperationError, match="Failed to disconnect container"):
             disconnect_func(network_id="net123", container_id="con123")
 
 
 class TestRemoveNetworkTool:
     """Test docker_remove_network tool."""
 
-    @pytest.fixture
-    def mock_docker_client(self):
-        """Create a mock Docker client."""
-        client = Mock(spec=DockerClientWrapper)
-        client.client = Mock()
-        client.client.networks = Mock()
-        return client
-
     def test_remove_network_success(self, mock_docker_client):
         """Test successfully removing a network."""
-        # Mock network object
         network = Mock()
         network.id = "net123"
         network.remove = Mock()
-
         mock_docker_client.client.networks.get.return_value = network
 
-        # Get the remove function
-        _, _, _, _, _, remove_func = create_remove_network_tool(mock_docker_client)
-
-        # Execute
+        *_, remove_func = create_remove_network_tool(mock_docker_client)
         result = remove_func(network_id="net123")
 
-        # Verify
         assert result["network_id"] == "net123"
         network.remove.assert_called_once()
-
-    def test_remove_network_not_found(self, mock_docker_client):
-        """Test removing non-existent network."""
-        mock_docker_client.client.networks.get.side_effect = NotFound("Network not found")
-
-        # Get the remove function
-        _, _, _, _, _, remove_func = create_remove_network_tool(mock_docker_client)
-
-        # Execute and expect error
-        with pytest.raises(NetworkNotFound, match="Network not found"):
-            remove_func(network_id="nonexistent")
-
-    def test_remove_network_api_error(self, mock_docker_client):
-        """Test removing network with API error."""
-        network = Mock()
-        network.id = "net123"
-        network.remove.side_effect = APIError("Remove failed")
-
-        mock_docker_client.client.networks.get.return_value = network
-
-        # Get the remove function
-        _, _, _, _, _, remove_func = create_remove_network_tool(mock_docker_client)
-
-        # Execute and expect error
-        with pytest.raises(DockerOperationError, match="Failed to remove network"):
-            remove_func(network_id="net123")

--- a/tests/unit/test_fastmcp_tools_system.py
+++ b/tests/unit/test_fastmcp_tools_system.py
@@ -5,33 +5,42 @@ from unittest.mock import Mock
 import pytest
 from docker.errors import APIError
 
-from mcp_docker.config import SafetyConfig
 from mcp_docker.docker_wrapper.client import DockerClientWrapper
 from mcp_docker.fastmcp_tools.system import create_prune_system_tool
 from mcp_docker.utils.errors import DockerOperationError
 
 
+# Module-level fixtures
+@pytest.fixture
+def mock_docker_client():
+    """Create a mock Docker client."""
+    client = Mock(spec=DockerClientWrapper)
+    client.client = Mock()
+    client.client.api = Mock()
+    client.client.images = Mock()
+    client.client.volumes = Mock()
+    return client
+
+
 class TestPruneSystemTool:
     """Test docker_prune_system tool."""
 
-    @pytest.fixture
-    def mock_docker_client(self):
-        """Create a mock Docker client."""
-        client = Mock(spec=DockerClientWrapper)
-        client.client = Mock()
-        client.client.api = Mock()
-        client.client.images = Mock()
-        client.client.volumes = Mock()
-        return client
-
-    @pytest.fixture
-    def safety_config(self):
-        """Create safety config."""
-        return SafetyConfig()
-
-    def test_prune_system_success_without_volumes(self, mock_docker_client, safety_config):
-        """Test successful system prune without volumes."""
-        # Mock Docker API responses
+    @pytest.mark.parametrize(
+        "volumes,expected_volumes_deleted,expected_space,volumes_call_expected",
+        [
+            (False, [], 6100, False),
+            (True, ["volume1", "volume2"], 8100, True),
+        ],
+    )
+    def test_prune_system_success(
+        self,
+        mock_docker_client,
+        volumes,
+        expected_volumes_deleted,
+        expected_space,
+        volumes_call_expected,
+    ):
+        """Test successful system prune with and without volumes."""
         mock_docker_client.client.api.prune_containers.return_value = {
             "ContainersDeleted": ["container1", "container2"],
             "SpaceReclaimed": 1000,
@@ -44,63 +53,31 @@ class TestPruneSystemTool:
             "NetworksDeleted": ["network1"],
             "SpaceReclaimed": 100,
         }
-
-        # Get the prune function
-        _, _, _, _, _, prune_func = create_prune_system_tool(mock_docker_client)
-
-        # Execute
-        result = prune_func()
-
-        # Verify
-        assert result["containers_deleted"] == ["container1", "container2"]
-        assert result["images_deleted"] == [{"Deleted": "sha256:abc123"}]
-        assert result["networks_deleted"] == ["network1"]
-        assert result["volumes_deleted"] == []
-        assert result["space_reclaimed"] == 6100  # 1000 + 5000 + 100
-
-        # Verify Docker API calls
-        mock_docker_client.client.api.prune_containers.assert_called_once_with(filters=None)
-        mock_docker_client.client.images.prune.assert_called_once_with(filters=None)
-        mock_docker_client.client.api.prune_networks.assert_called_once_with(filters=None)
-        mock_docker_client.client.volumes.prune.assert_not_called()
-
-    def test_prune_system_success_with_volumes(self, mock_docker_client, safety_config):
-        """Test successful system prune with volumes."""
-        # Mock Docker API responses
-        mock_docker_client.client.api.prune_containers.return_value = {
-            "ContainersDeleted": ["container1"],
-            "SpaceReclaimed": 500,
-        }
-        mock_docker_client.client.images.prune.return_value = {
-            "ImagesDeleted": [],
-            "SpaceReclaimed": 0,
-        }
-        mock_docker_client.client.api.prune_networks.return_value = {
-            "NetworksDeleted": [],
-            "SpaceReclaimed": 0,
-        }
         mock_docker_client.client.volumes.prune.return_value = {
             "VolumesDeleted": ["volume1", "volume2"],
             "SpaceReclaimed": 2000,
         }
 
-        # Get the prune function
-        _, _, _, _, _, prune_func = create_prune_system_tool(mock_docker_client)
+        *_, prune_func = create_prune_system_tool(mock_docker_client)
+        result = prune_func(volumes=volumes)
 
-        # Execute with volumes=True
-        result = prune_func(volumes=True)
+        assert result["containers_deleted"] == ["container1", "container2"]
+        assert result["images_deleted"] == [{"Deleted": "sha256:abc123"}]
+        assert result["networks_deleted"] == ["network1"]
+        assert result["volumes_deleted"] == expected_volumes_deleted
+        assert result["space_reclaimed"] == expected_space
 
-        # Verify
-        assert result["containers_deleted"] == ["container1"]
-        assert result["volumes_deleted"] == ["volume1", "volume2"]
-        assert result["space_reclaimed"] == 2500  # 500 + 2000
+        mock_docker_client.client.api.prune_containers.assert_called_once_with(filters=None)
+        mock_docker_client.client.images.prune.assert_called_once_with(filters=None)
+        mock_docker_client.client.api.prune_networks.assert_called_once_with(filters=None)
 
-        # Verify volumes.prune was called
-        mock_docker_client.client.volumes.prune.assert_called_once_with(filters=None)
+        if volumes_call_expected:
+            mock_docker_client.client.volumes.prune.assert_called_once_with(filters=None)
+        else:
+            mock_docker_client.client.volumes.prune.assert_not_called()
 
-    def test_prune_system_with_filters(self, mock_docker_client, safety_config):
+    def test_prune_system_with_filters(self, mock_docker_client):
         """Test system prune with filters."""
-        # Mock Docker API responses
         mock_docker_client.client.api.prune_containers.return_value = {
             "ContainersDeleted": [],
             "SpaceReclaimed": 0,
@@ -114,23 +91,17 @@ class TestPruneSystemTool:
             "SpaceReclaimed": 0,
         }
 
-        # Get the prune function
-        _, _, _, _, _, prune_func = create_prune_system_tool(mock_docker_client)
-
-        # Execute with filters
+        *_, prune_func = create_prune_system_tool(mock_docker_client)
         filters = {"until": "24h"}
         result = prune_func(filters=filters)
 
-        # Verify filters were passed
         mock_docker_client.client.api.prune_containers.assert_called_once_with(filters=filters)
         mock_docker_client.client.images.prune.assert_called_once_with(filters=filters)
         mock_docker_client.client.api.prune_networks.assert_called_once_with(filters=filters)
-
         assert result["space_reclaimed"] == 0
 
-    def test_prune_system_empty_results(self, mock_docker_client, safety_config):
-        """Test system prune with no resources to delete."""
-        # Mock Docker API responses with None (no deletions)
+    def test_prune_system_empty_results(self, mock_docker_client):
+        """Test system prune with no resources to delete (None values)."""
         mock_docker_client.client.api.prune_containers.return_value = {
             "ContainersDeleted": None,
             "SpaceReclaimed": 0,
@@ -144,32 +115,25 @@ class TestPruneSystemTool:
             "SpaceReclaimed": 0,
         }
 
-        # Get the prune function
-        _, _, _, _, _, prune_func = create_prune_system_tool(mock_docker_client)
-
-        # Execute
+        *_, prune_func = create_prune_system_tool(mock_docker_client)
         result = prune_func()
 
-        # Verify empty lists (None -> [])
         assert result["containers_deleted"] == []
         assert result["images_deleted"] == []
         assert result["networks_deleted"] == []
         assert result["volumes_deleted"] == []
         assert result["space_reclaimed"] == 0
 
-    def test_prune_system_api_error(self, mock_docker_client, safety_config):
+    def test_prune_system_api_error(self, mock_docker_client):
         """Test system prune with Docker API error."""
-        # Mock Docker API to raise error
         mock_docker_client.client.api.prune_containers.side_effect = APIError("Prune failed")
 
-        # Get the prune function
-        _, _, _, _, _, prune_func = create_prune_system_tool(mock_docker_client)
+        *_, prune_func = create_prune_system_tool(mock_docker_client)
 
-        # Execute and expect error
         with pytest.raises(DockerOperationError, match="Failed to prune system"):
             prune_func()
 
-    def test_create_prune_system_tool_metadata(self, mock_docker_client, safety_config):
+    def test_create_prune_system_tool_metadata(self, mock_docker_client):
         """Test tool metadata is correct."""
         name, description, safety_level, idempotent, open_world, func = create_prune_system_tool(
             mock_docker_client
@@ -178,6 +142,6 @@ class TestPruneSystemTool:
         assert name == "docker_prune_system"
         assert "Prune all unused Docker resources" in description
         assert safety_level.value == "destructive"
-        assert idempotent is False  # Different resources each time
+        assert idempotent is False
         assert open_world is False
         assert callable(func)

--- a/tests/unit/test_fastmcp_tools_volume.py
+++ b/tests/unit/test_fastmcp_tools_volume.py
@@ -17,25 +17,116 @@ from mcp_docker.fastmcp_tools.volume import (
 from mcp_docker.utils.errors import DockerOperationError, VolumeNotFound
 
 
+# Module-level fixtures to avoid duplication across test classes
+@pytest.fixture
+def mock_docker_client():
+    """Create a mock Docker client."""
+    client = Mock(spec=DockerClientWrapper)
+    client.client = Mock()
+    client.client.volumes = Mock()
+    return client
+
+
+@pytest.fixture
+def safety_config():
+    """Create safety config."""
+    return SafetyConfig()
+
+
+class TestVolumeNotFoundErrors:
+    """Test volume not found error handling across tools."""
+
+    @pytest.mark.parametrize(
+        "tool_creator,call_kwargs",
+        [
+            (create_inspect_volume_tool, {"volume_name": "nonexistent"}),
+            (create_remove_volume_tool, {"volume_name": "nonexistent"}),
+        ],
+    )
+    def test_volume_not_found(self, mock_docker_client, tool_creator, call_kwargs):
+        """Test that VolumeNotFound is raised when volume doesn't exist."""
+        mock_docker_client.client.volumes.get.side_effect = NotFound("Volume not found")
+
+        *_, func = tool_creator(mock_docker_client)
+
+        with pytest.raises(VolumeNotFound, match="Volume not found"):
+            func(**call_kwargs)
+
+
+class TestAPIErrors:
+    """Test API error handling across tools."""
+
+    @pytest.mark.parametrize(
+        "tool_creator,needs_safety_config,call_kwargs,error_match,setup_error_on",
+        [
+            (create_list_volumes_tool, True, {}, "Failed to list volumes", "volumes.list"),
+            (
+                create_inspect_volume_tool,
+                False,
+                {"volume_name": "test"},
+                "Failed to inspect volume",
+                "volumes.get",
+            ),
+            (
+                create_create_volume_tool,
+                False,
+                {"name": "test"},
+                "Failed to create volume",
+                "volumes.create",
+            ),
+            (
+                create_prune_volumes_tool,
+                False,
+                {"force_all": False},
+                "Failed to prune volumes",
+                "volumes.prune",
+            ),
+        ],
+    )
+    def test_api_error(  # noqa: PLR0913
+        self,
+        mock_docker_client,
+        safety_config,
+        tool_creator,
+        needs_safety_config,
+        call_kwargs,
+        error_match,
+        setup_error_on,
+    ):
+        """Test that DockerOperationError is raised on API errors."""
+        method_mapping = {
+            "volumes.list": mock_docker_client.client.volumes.list,
+            "volumes.get": mock_docker_client.client.volumes.get,
+            "volumes.create": mock_docker_client.client.volumes.create,
+            "volumes.prune": mock_docker_client.client.volumes.prune,
+        }
+        method_mapping[setup_error_on].side_effect = APIError("API failed")
+
+        if needs_safety_config:
+            *_, func = tool_creator(mock_docker_client, safety_config)
+        else:
+            *_, func = tool_creator(mock_docker_client)
+
+        with pytest.raises(DockerOperationError, match=error_match):
+            func(**call_kwargs)
+
+    def test_remove_volume_api_error(self, mock_docker_client):
+        """Test volume removal with API error."""
+        volume = Mock()
+        volume.remove.side_effect = APIError("Remove failed")
+        mock_docker_client.client.volumes.get.return_value = volume
+
+        *_, remove_func = create_remove_volume_tool(mock_docker_client)
+
+        with pytest.raises(DockerOperationError, match="Failed to remove volume"):
+            remove_func(volume_name="test-volume")
+
+
 class TestListVolumesTool:
     """Test docker_list_volumes tool."""
 
-    @pytest.fixture
-    def mock_docker_client(self):
-        """Create a mock Docker client."""
-        client = Mock(spec=DockerClientWrapper)
-        client.client = Mock()
-        client.client.volumes = Mock()
-        return client
-
-    @pytest.fixture
-    def safety_config(self):
-        """Create safety config."""
-        return SafetyConfig()
-
     def test_list_volumes_success(self, mock_docker_client, safety_config):
         """Test successful volume listing."""
-        # Mock volume objects
         vol1 = Mock()
         vol1.name = "volume1"
         vol1.attrs = {
@@ -56,13 +147,9 @@ class TestListVolumesTool:
 
         mock_docker_client.client.volumes.list.return_value = [vol1, vol2]
 
-        # Get the list function
-        _, _, _, _, _, list_func = create_list_volumes_tool(mock_docker_client, safety_config)
-
-        # Execute
+        *_, list_func = create_list_volumes_tool(mock_docker_client, safety_config)
         result = list_func()
 
-        # Verify
         assert result["count"] == 2
         assert len(result["volumes"]) == 2
         assert result["volumes"][0]["name"] == "volume1"
@@ -74,48 +161,19 @@ class TestListVolumesTool:
         """Test volume listing with filters."""
         mock_docker_client.client.volumes.list.return_value = []
 
-        # Get the list function
-        _, _, _, _, _, list_func = create_list_volumes_tool(mock_docker_client, safety_config)
-
-        # Execute with filters
+        *_, list_func = create_list_volumes_tool(mock_docker_client, safety_config)
         filters = {"dangling": ["true"]}
         result = list_func(filters=filters)
 
-        # Verify filters were passed
         mock_docker_client.client.volumes.list.assert_called_once_with(filters=filters)
         assert result["count"] == 0
-
-    def test_list_volumes_api_error(self, mock_docker_client, safety_config):
-        """Test volume listing with API error."""
-        mock_docker_client.client.volumes.list.side_effect = APIError("List failed")
-
-        # Get the list function
-        _, _, _, _, _, list_func = create_list_volumes_tool(mock_docker_client, safety_config)
-
-        # Execute and expect error
-        with pytest.raises(DockerOperationError, match="Failed to list volumes"):
-            list_func()
 
 
 class TestInspectVolumeTool:
     """Test docker_inspect_volume tool."""
 
-    @pytest.fixture
-    def mock_docker_client(self):
-        """Create a mock Docker client."""
-        client = Mock(spec=DockerClientWrapper)
-        client.client = Mock()
-        client.client.volumes = Mock()
-        return client
-
-    @pytest.fixture
-    def safety_config(self):
-        """Create safety config."""
-        return SafetyConfig()
-
-    def test_inspect_volume_success(self, mock_docker_client, safety_config):
+    def test_inspect_volume_success(self, mock_docker_client):
         """Test successful volume inspection."""
-        # Mock volume object
         volume = Mock()
         volume.attrs = {
             "Name": "test-volume",
@@ -124,99 +182,45 @@ class TestInspectVolumeTool:
             "CreatedAt": "2024-01-01T00:00:00Z",
             "Labels": {"env": "prod"},
         }
-
         mock_docker_client.client.volumes.get.return_value = volume
 
-        # Get the inspect function
-        _, _, _, _, _, inspect_func = create_inspect_volume_tool(mock_docker_client)
-
-        # Execute
+        *_, inspect_func = create_inspect_volume_tool(mock_docker_client)
         result = inspect_func(volume_name="test-volume")
 
-        # Verify
         assert result["details"]["Name"] == "test-volume"
         assert result["details"]["Driver"] == "local"
         assert result["details"]["Labels"] == {"env": "prod"}
         mock_docker_client.client.volumes.get.assert_called_once_with("test-volume")
 
-    def test_inspect_volume_not_found(self, mock_docker_client, safety_config):
-        """Test inspecting non-existent volume."""
-        mock_docker_client.client.volumes.get.side_effect = NotFound("Volume not found")
-
-        # Get the inspect function
-        _, _, _, _, _, inspect_func = create_inspect_volume_tool(mock_docker_client)
-
-        # Execute and expect error
-        with pytest.raises(VolumeNotFound, match="Volume not found"):
-            inspect_func(volume_name="nonexistent")
-
-    def test_inspect_volume_api_error(self, mock_docker_client, safety_config):
-        """Test volume inspection with API error."""
-        mock_docker_client.client.volumes.get.side_effect = APIError("Inspect failed")
-
-        # Get the inspect function
-        _, _, _, _, _, inspect_func = create_inspect_volume_tool(mock_docker_client)
-
-        # Execute and expect error
-        with pytest.raises(DockerOperationError, match="Failed to inspect volume"):
-            inspect_func(volume_name="test-volume")
-
 
 class TestCreateVolumeTool:
     """Test docker_create_volume tool."""
 
-    @pytest.fixture
-    def mock_docker_client(self):
-        """Create a mock Docker client."""
-        client = Mock(spec=DockerClientWrapper)
-        client.client = Mock()
-        client.client.volumes = Mock()
-        return client
-
-    @pytest.fixture
-    def safety_config(self):
-        """Create safety config."""
-        return SafetyConfig()
-
-    def test_create_volume_success(self, mock_docker_client, safety_config):
+    def test_create_volume_success(self, mock_docker_client):
         """Test successful volume creation."""
-        # Mock volume object
         volume = Mock()
         volume.name = "test-volume"
         volume.attrs = {
             "Driver": "local",
             "Mountpoint": "/var/lib/docker/volumes/test-volume/_data",
         }
-
         mock_docker_client.client.volumes.create.return_value = volume
 
-        # Get the create function
-        _, _, _, _, _, create_func = create_create_volume_tool(mock_docker_client)
-
-        # Execute
+        *_, create_func = create_create_volume_tool(mock_docker_client)
         result = create_func(name="test-volume")
 
-        # Verify
         assert result["name"] == "test-volume"
         assert result["driver"] == "local"
         mock_docker_client.client.volumes.create.assert_called_once()
 
-    def test_create_volume_with_options(self, mock_docker_client, safety_config):
+    def test_create_volume_with_options(self, mock_docker_client):
         """Test volume creation with driver options and labels."""
-        # Mock volume object
         volume = Mock()
         volume.name = "nfs-volume"
-        volume.attrs = {
-            "Driver": "nfs",
-            "Mountpoint": "/mnt/nfs",
-        }
-
+        volume.attrs = {"Driver": "nfs", "Mountpoint": "/mnt/nfs"}
         mock_docker_client.client.volumes.create.return_value = volume
 
-        # Get the create function
-        _, _, _, _, _, create_func = create_create_volume_tool(mock_docker_client)
-
-        # Execute with options
+        *_, create_func = create_create_volume_tool(mock_docker_client)
         create_func(
             name="nfs-volume",
             driver="nfs",
@@ -224,186 +228,81 @@ class TestCreateVolumeTool:
             labels={"env": "prod"},
         )
 
-        # Verify options were passed
         call_args = mock_docker_client.client.volumes.create.call_args
         assert call_args.kwargs["name"] == "nfs-volume"
         assert call_args.kwargs["driver"] == "nfs"
         assert call_args.kwargs["driver_opts"] == {"type": "nfs", "device": ":/path"}
         assert call_args.kwargs["labels"] == {"env": "prod"}
 
-    def test_create_volume_auto_name(self, mock_docker_client, safety_config):
+    def test_create_volume_auto_name(self, mock_docker_client):
         """Test volume creation with auto-generated name."""
-        # Mock volume object
         volume = Mock()
         volume.name = "auto-generated-123"
         volume.attrs = {"Driver": "local", "Mountpoint": "/var/lib/docker/volumes/..."}
-
         mock_docker_client.client.volumes.create.return_value = volume
 
-        # Get the create function
-        _, _, _, _, _, create_func = create_create_volume_tool(mock_docker_client)
-
-        # Execute without name
+        *_, create_func = create_create_volume_tool(mock_docker_client)
         result = create_func()
 
-        # Verify auto-generated name was used
         assert result["name"] == "auto-generated-123"
-
-    def test_create_volume_api_error(self, mock_docker_client, safety_config):
-        """Test volume creation with API error."""
-        mock_docker_client.client.volumes.create.side_effect = APIError("Create failed")
-
-        # Get the create function
-        _, _, _, _, _, create_func = create_create_volume_tool(mock_docker_client)
-
-        # Execute and expect error
-        with pytest.raises(DockerOperationError, match="Failed to create volume"):
-            create_func(name="test-volume")
 
 
 class TestRemoveVolumeTool:
     """Test docker_remove_volume tool."""
 
-    @pytest.fixture
-    def mock_docker_client(self):
-        """Create a mock Docker client."""
-        client = Mock(spec=DockerClientWrapper)
-        client.client = Mock()
-        client.client.volumes = Mock()
-        return client
-
-    @pytest.fixture
-    def safety_config(self):
-        """Create safety config."""
-        return SafetyConfig()
-
-    def test_remove_volume_success(self, mock_docker_client, safety_config):
-        """Test successful volume removal."""
-        # Mock volume object
+    @pytest.mark.parametrize(
+        "force,expected_force",
+        [
+            (False, False),
+            (True, True),
+        ],
+    )
+    def test_remove_volume(self, mock_docker_client, force, expected_force):
+        """Test volume removal with and without force flag."""
         volume = Mock()
         volume.remove = Mock()
-
         mock_docker_client.client.volumes.get.return_value = volume
 
-        # Get the remove function
-        _, _, _, _, _, remove_func = create_remove_volume_tool(mock_docker_client)
+        *_, remove_func = create_remove_volume_tool(mock_docker_client)
+        result = remove_func(volume_name="test-volume", force=force)
 
-        # Execute
-        result = remove_func(volume_name="test-volume")
-
-        # Verify
         assert result["volume_name"] == "test-volume"
         mock_docker_client.client.volumes.get.assert_called_once_with("test-volume")
-        volume.remove.assert_called_once_with(force=False)
-
-    def test_remove_volume_with_force(self, mock_docker_client, safety_config):
-        """Test volume removal with force flag."""
-        # Mock volume object
-        volume = Mock()
-        volume.remove = Mock()
-
-        mock_docker_client.client.volumes.get.return_value = volume
-
-        # Get the remove function
-        _, _, _, _, _, remove_func = create_remove_volume_tool(mock_docker_client)
-
-        # Execute with force
-        remove_func(volume_name="test-volume", force=True)
-
-        # Verify force was used
-        volume.remove.assert_called_once_with(force=True)
-
-    def test_remove_volume_not_found(self, mock_docker_client, safety_config):
-        """Test removing non-existent volume."""
-        mock_docker_client.client.volumes.get.side_effect = NotFound("Volume not found")
-
-        # Get the remove function
-        _, _, _, _, _, remove_func = create_remove_volume_tool(mock_docker_client)
-
-        # Execute and expect error
-        with pytest.raises(VolumeNotFound, match="Volume not found"):
-            remove_func(volume_name="nonexistent")
-
-    def test_remove_volume_api_error(self, mock_docker_client, safety_config):
-        """Test volume removal with API error."""
-        volume = Mock()
-        volume.remove.side_effect = APIError("Remove failed")
-
-        mock_docker_client.client.volumes.get.return_value = volume
-
-        # Get the remove function
-        _, _, _, _, _, remove_func = create_remove_volume_tool(mock_docker_client)
-
-        # Execute and expect error
-        with pytest.raises(DockerOperationError, match="Failed to remove volume"):
-            remove_func(volume_name="test-volume")
+        volume.remove.assert_called_once_with(force=expected_force)
 
 
 class TestPruneVolumesTool:
     """Test docker_prune_volumes tool."""
 
-    @pytest.fixture
-    def mock_docker_client(self):
-        """Create a mock Docker client."""
-        client = Mock(spec=DockerClientWrapper)
-        client.client = Mock()
-        client.client.volumes = Mock()
-        return client
-
-    @pytest.fixture
-    def safety_config(self):
-        """Create safety config."""
-        return SafetyConfig()
-
-    def test_prune_volumes_standard(self, mock_docker_client, safety_config):
+    def test_prune_volumes_standard(self, mock_docker_client):
         """Test standard volume prune (unused only)."""
         mock_docker_client.client.volumes.prune.return_value = {
             "VolumesDeleted": ["volume1", "volume2"],
             "SpaceReclaimed": 5000,
         }
 
-        # Get the prune function
-        _, _, _, _, _, prune_func = create_prune_volumes_tool(mock_docker_client)
-
-        # Execute standard prune
+        *_, prune_func = create_prune_volumes_tool(mock_docker_client)
         result = prune_func(force_all=False)
 
-        # Verify
         assert result["deleted"] == ["volume1", "volume2"]
         assert result["space_reclaimed"] == 5000
         mock_docker_client.client.volumes.prune.assert_called_once_with(filters=None)
 
-    def test_prune_volumes_with_filters(self, mock_docker_client, safety_config):
+    def test_prune_volumes_with_filters(self, mock_docker_client):
         """Test volume prune with filters."""
         mock_docker_client.client.volumes.prune.return_value = {
             "VolumesDeleted": [],
             "SpaceReclaimed": 0,
         }
 
-        # Get the prune function
-        _, _, _, _, _, prune_func = create_prune_volumes_tool(mock_docker_client)
-
-        # Execute with filters
+        *_, prune_func = create_prune_volumes_tool(mock_docker_client)
         filters = {"label": ["env=test"]}
         prune_func(filters=filters, force_all=False)
 
-        # Verify filters were passed
         mock_docker_client.client.volumes.prune.assert_called_once_with(filters=filters)
 
-    def test_prune_volumes_api_error(self, mock_docker_client, safety_config):
-        """Test volume prune with API error."""
-        mock_docker_client.client.volumes.prune.side_effect = APIError("Prune failed")
-
-        # Get the prune function
-        _, _, _, _, _, prune_func = create_prune_volumes_tool(mock_docker_client)
-
-        # Execute and expect error
-        with pytest.raises(DockerOperationError, match="Failed to prune volumes"):
-            prune_func(force_all=False)
-
-    def test_prune_volumes_force_all(self, mock_docker_client, safety_config):
+    def test_prune_volumes_force_all(self, mock_docker_client):
         """Test force removing all volumes."""
-        # Create mock volumes
         volume1 = Mock()
         volume1.name = "test-vol-1"
 
@@ -412,7 +311,6 @@ class TestPruneVolumesTool:
 
         mock_docker_client.client.volumes.list.return_value = [volume1, volume2]
 
-        # Mock get and remove
         def get_side_effect(name):
             vol = Mock()
             vol.remove = Mock()
@@ -420,24 +318,17 @@ class TestPruneVolumesTool:
 
         mock_docker_client.client.volumes.get.side_effect = get_side_effect
 
-        # Get the prune function
-        _, _, _, _, _, prune_func = create_prune_volumes_tool(mock_docker_client)
-
-        # Execute with force_all=True
+        *_, prune_func = create_prune_volumes_tool(mock_docker_client)
         result = prune_func(force_all=True)
 
-        # Verify all volumes were force removed
         assert len(result["deleted"]) == 2
         assert "test-vol-1" in result["deleted"]
         assert "test-vol-2" in result["deleted"]
-        assert result["space_reclaimed"] == 0  # force_all doesn't track space
-
-        # Verify get and remove were called with force=True
+        assert result["space_reclaimed"] == 0
         assert mock_docker_client.client.volumes.get.call_count == 2
 
-    def test_prune_volumes_force_all_with_errors(self, mock_docker_client, safety_config):
+    def test_prune_volumes_force_all_with_errors(self, mock_docker_client):
         """Test force removing all volumes with some failures."""
-        # Create mock volumes
         volume1 = Mock()
         volume1.name = "error-vol"
 
@@ -446,23 +337,18 @@ class TestPruneVolumesTool:
 
         mock_docker_client.client.volumes.list.return_value = [volume1, volume2]
 
-        # Mock get to return volumes that can be removed
         def get_side_effect(name):
             vol = Mock()
             if name == "error-vol":
                 vol.remove.side_effect = APIError("Volume in use")
             else:
-                vol.remove = Mock()  # Succeeds
+                vol.remove = Mock()
             return vol
 
         mock_docker_client.client.volumes.get.side_effect = get_side_effect
 
-        # Get the prune function
-        _, _, _, _, _, prune_func = create_prune_volumes_tool(mock_docker_client)
-
-        # Execute with force_all=True
+        *_, prune_func = create_prune_volumes_tool(mock_docker_client)
         result = prune_func(force_all=True)
 
-        # Should continue after first failure
         assert len(result["deleted"]) == 1
         assert result["deleted"][0] == "success-vol"

--- a/tests/unit/test_http_helpers.py
+++ b/tests/unit/test_http_helpers.py
@@ -1,0 +1,346 @@
+"""Tests for HTTP helper utilities."""
+
+from unittest.mock import MagicMock, Mock, patch
+
+from mcp_docker.utils.http_helpers import extract_client_ip
+
+
+class TestExtractClientIp:
+    """Tests for extract_client_ip function."""
+
+    def test_extract_from_fastmcp_dependency_injection(self) -> None:
+        """Test extracting IP from FastMCP's get_http_request()."""
+        mock_request = Mock()
+        mock_request.client = Mock()
+        mock_request.client.host = "192.168.1.100"
+
+        mock_context = MagicMock()
+
+        with patch("mcp_docker.utils.http_helpers.get_http_request", return_value=mock_request):
+            result = extract_client_ip(mock_context)
+
+        assert result == "192.168.1.100"
+
+    def test_fallback_to_context_extraction_on_runtime_error(self) -> None:
+        """Test fallback when get_http_request() raises RuntimeError."""
+        # Create mocked context with nested request structure
+        mock_client = Mock()
+        mock_client.host = "10.0.0.50"
+
+        mock_request = Mock()
+        mock_request.client = mock_client
+
+        mock_request_context = Mock()
+        mock_request_context.request = mock_request
+
+        mock_fastmcp_context = Mock()
+        mock_fastmcp_context.request_context = mock_request_context
+
+        mock_context = MagicMock()
+        mock_context.fastmcp_context = mock_fastmcp_context
+
+        with patch(
+            "mcp_docker.utils.http_helpers.get_http_request",
+            side_effect=RuntimeError("Not in HTTP context"),
+        ):
+            result = extract_client_ip(mock_context)
+
+        assert result == "10.0.0.50"
+
+    def test_fallback_to_context_extraction_on_lookup_error(self) -> None:
+        """Test fallback when get_http_request() raises LookupError."""
+        mock_client = Mock()
+        mock_client.host = "172.16.0.1"
+
+        mock_request = Mock()
+        mock_request.client = mock_client
+
+        mock_request_context = Mock()
+        mock_request_context.request = mock_request
+
+        mock_fastmcp_context = Mock()
+        mock_fastmcp_context.request_context = mock_request_context
+
+        mock_context = MagicMock()
+        mock_context.fastmcp_context = mock_fastmcp_context
+
+        with patch(
+            "mcp_docker.utils.http_helpers.get_http_request",
+            side_effect=LookupError("Dependency not available"),
+        ):
+            result = extract_client_ip(mock_context)
+
+        assert result == "172.16.0.1"
+
+    def test_returns_none_when_no_fastmcp_context(self) -> None:
+        """Test returns None when fastmcp_context is not available."""
+        mock_context = MagicMock()
+        mock_context.fastmcp_context = None
+
+        with patch(
+            "mcp_docker.utils.http_helpers.get_http_request",
+            side_effect=RuntimeError("Not in HTTP context"),
+        ):
+            result = extract_client_ip(mock_context)
+
+        assert result is None
+
+    def test_returns_none_when_no_request_context(self) -> None:
+        """Test returns None when request_context attribute is missing."""
+        mock_fastmcp_context = Mock(spec=[])  # No request_context attribute
+
+        mock_context = MagicMock()
+        mock_context.fastmcp_context = mock_fastmcp_context
+
+        with patch(
+            "mcp_docker.utils.http_helpers.get_http_request",
+            side_effect=RuntimeError("Not in HTTP context"),
+        ):
+            result = extract_client_ip(mock_context)
+
+        assert result is None
+
+    def test_returns_none_when_request_context_is_none(self) -> None:
+        """Test returns None when request_context is None."""
+        mock_fastmcp_context = Mock()
+        mock_fastmcp_context.request_context = None
+
+        mock_context = MagicMock()
+        mock_context.fastmcp_context = mock_fastmcp_context
+
+        with patch(
+            "mcp_docker.utils.http_helpers.get_http_request",
+            side_effect=RuntimeError("Not in HTTP context"),
+        ):
+            result = extract_client_ip(mock_context)
+
+        assert result is None
+
+    def test_returns_none_when_no_request_in_context(self) -> None:
+        """Test returns None when request is missing from request_context."""
+        mock_request_context = Mock(spec=[])  # No request attribute
+
+        mock_fastmcp_context = Mock()
+        mock_fastmcp_context.request_context = mock_request_context
+
+        mock_context = MagicMock()
+        mock_context.fastmcp_context = mock_fastmcp_context
+
+        with patch(
+            "mcp_docker.utils.http_helpers.get_http_request",
+            side_effect=RuntimeError("Not in HTTP context"),
+        ):
+            result = extract_client_ip(mock_context)
+
+        assert result is None
+
+    def test_returns_none_when_request_is_none(self) -> None:
+        """Test returns None when request is None."""
+        mock_request_context = Mock()
+        mock_request_context.request = None
+
+        mock_fastmcp_context = Mock()
+        mock_fastmcp_context.request_context = mock_request_context
+
+        mock_context = MagicMock()
+        mock_context.fastmcp_context = mock_fastmcp_context
+
+        with patch(
+            "mcp_docker.utils.http_helpers.get_http_request",
+            side_effect=RuntimeError("Not in HTTP context"),
+        ):
+            result = extract_client_ip(mock_context)
+
+        assert result is None
+
+    def test_returns_none_when_no_client_in_request(self) -> None:
+        """Test returns None when client is missing from request."""
+        mock_request = Mock(spec=[])  # No client attribute
+
+        mock_request_context = Mock()
+        mock_request_context.request = mock_request
+
+        mock_fastmcp_context = Mock()
+        mock_fastmcp_context.request_context = mock_request_context
+
+        mock_context = MagicMock()
+        mock_context.fastmcp_context = mock_fastmcp_context
+
+        with patch(
+            "mcp_docker.utils.http_helpers.get_http_request",
+            side_effect=RuntimeError("Not in HTTP context"),
+        ):
+            result = extract_client_ip(mock_context)
+
+        assert result is None
+
+    def test_returns_none_when_client_is_none(self) -> None:
+        """Test returns None when client is None."""
+        mock_request = Mock()
+        mock_request.client = None
+
+        mock_request_context = Mock()
+        mock_request_context.request = mock_request
+
+        mock_fastmcp_context = Mock()
+        mock_fastmcp_context.request_context = mock_request_context
+
+        mock_context = MagicMock()
+        mock_context.fastmcp_context = mock_fastmcp_context
+
+        with patch(
+            "mcp_docker.utils.http_helpers.get_http_request",
+            side_effect=RuntimeError("Not in HTTP context"),
+        ):
+            result = extract_client_ip(mock_context)
+
+        assert result is None
+
+    def test_returns_none_when_client_host_is_none(self) -> None:
+        """Test returns None when client.host is None."""
+        mock_client = Mock()
+        mock_client.host = None
+
+        mock_request = Mock()
+        mock_request.client = mock_client
+
+        mock_request_context = Mock()
+        mock_request_context.request = mock_request
+
+        mock_fastmcp_context = Mock()
+        mock_fastmcp_context.request_context = mock_request_context
+
+        mock_context = MagicMock()
+        mock_context.fastmcp_context = mock_fastmcp_context
+
+        with patch(
+            "mcp_docker.utils.http_helpers.get_http_request",
+            side_effect=RuntimeError("Not in HTTP context"),
+        ):
+            result = extract_client_ip(mock_context)
+
+        assert result is None
+
+    def test_returns_none_when_client_has_no_host_attribute(self) -> None:
+        """Test returns None when client lacks host attribute."""
+        mock_client = Mock(spec=[])  # No host attribute
+
+        mock_request = Mock()
+        mock_request.client = mock_client
+
+        mock_request_context = Mock()
+        mock_request_context.request = mock_request
+
+        mock_fastmcp_context = Mock()
+        mock_fastmcp_context.request_context = mock_request_context
+
+        mock_context = MagicMock()
+        mock_context.fastmcp_context = mock_fastmcp_context
+
+        with patch(
+            "mcp_docker.utils.http_helpers.get_http_request",
+            side_effect=RuntimeError("Not in HTTP context"),
+        ):
+            result = extract_client_ip(mock_context)
+
+        assert result is None
+
+    def test_handles_ipv6_address(self) -> None:
+        """Test extracting IPv6 address."""
+        mock_request = Mock()
+        mock_request.client = Mock()
+        mock_request.client.host = "::1"
+
+        mock_context = MagicMock()
+
+        with patch("mcp_docker.utils.http_helpers.get_http_request", return_value=mock_request):
+            result = extract_client_ip(mock_context)
+
+        assert result == "::1"
+
+    def test_handles_full_ipv6_address(self) -> None:
+        """Test extracting full IPv6 address."""
+        mock_request = Mock()
+        mock_request.client = Mock()
+        mock_request.client.host = "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+
+        mock_context = MagicMock()
+
+        with patch("mcp_docker.utils.http_helpers.get_http_request", return_value=mock_request):
+            result = extract_client_ip(mock_context)
+
+        assert result == "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+
+    def test_dependency_injection_returns_none(self) -> None:
+        """Test when get_http_request() returns None."""
+        mock_context = MagicMock()
+        mock_context.fastmcp_context = None
+
+        with patch("mcp_docker.utils.http_helpers.get_http_request", return_value=None):
+            result = extract_client_ip(mock_context)
+
+        assert result is None
+
+    def test_dependency_injection_request_has_no_client_attr(self) -> None:
+        """Test when request from dependency injection has no client attribute."""
+        mock_request = Mock(spec=[])  # No client attribute
+
+        mock_context = MagicMock()
+        mock_context.fastmcp_context = None
+
+        with patch("mcp_docker.utils.http_helpers.get_http_request", return_value=mock_request):
+            result = extract_client_ip(mock_context)
+
+        assert result is None
+
+    def test_dependency_injection_client_is_none(self) -> None:
+        """Test when request.client from dependency injection is None."""
+        mock_request = Mock()
+        mock_request.client = None
+
+        mock_context = MagicMock()
+        mock_context.fastmcp_context = None
+
+        with patch("mcp_docker.utils.http_helpers.get_http_request", return_value=mock_request):
+            result = extract_client_ip(mock_context)
+
+        assert result is None
+
+    def test_dependency_injection_client_has_no_host(self) -> None:
+        """Test when request.client from dependency injection has no host."""
+        mock_client = Mock(spec=[])  # No host attribute
+        mock_request = Mock()
+        mock_request.client = mock_client
+
+        mock_context = MagicMock()
+        mock_context.fastmcp_context = None
+
+        with patch("mcp_docker.utils.http_helpers.get_http_request", return_value=mock_request):
+            result = extract_client_ip(mock_context)
+
+        assert result is None
+
+    def test_converts_non_string_host_to_string(self) -> None:
+        """Test that non-string host values are converted to string."""
+        mock_client = Mock()
+        mock_client.host = 12345  # Integer instead of string
+
+        mock_request = Mock()
+        mock_request.client = mock_client
+
+        mock_request_context = Mock()
+        mock_request_context.request = mock_request
+
+        mock_fastmcp_context = Mock()
+        mock_fastmcp_context.request_context = mock_request_context
+
+        mock_context = MagicMock()
+        mock_context.fastmcp_context = mock_fastmcp_context
+
+        with patch(
+            "mcp_docker.utils.http_helpers.get_http_request",
+            side_effect=RuntimeError("Not in HTTP context"),
+        ):
+            result = extract_client_ip(mock_context)
+
+        assert result == "12345"

--- a/tests/unit/test_stats_formatter.py
+++ b/tests/unit/test_stats_formatter.py
@@ -1,0 +1,269 @@
+"""Tests for stats_formatter utility module."""
+
+import pytest
+
+from mcp_docker.utils.stats_formatter import (
+    calculate_cpu_usage,
+    calculate_memory_usage,
+    format_network_stats,
+)
+
+
+class TestCalculateMemoryUsage:
+    """Tests for calculate_memory_usage function."""
+
+    def test_normal_memory_usage(self) -> None:
+        """Test calculating memory usage with typical values."""
+        stats = {
+            "memory_stats": {
+                "usage": 104857600,  # 100 MB
+                "limit": 1073741824,  # 1 GB
+            }
+        }
+
+        result = calculate_memory_usage(stats)
+
+        assert result["usage_bytes"] == 104857600
+        assert result["limit_bytes"] == 1073741824
+        assert result["usage_mb"] == pytest.approx(100.0)
+        assert result["limit_mb"] == pytest.approx(1024.0)
+        assert result["percent"] == pytest.approx(9.765625)
+
+    def test_empty_stats(self) -> None:
+        """Test calculating memory usage with empty stats."""
+        stats: dict = {}
+
+        result = calculate_memory_usage(stats)
+
+        assert result["usage_bytes"] == 0
+        assert result["limit_bytes"] == 0
+        assert result["usage_mb"] == 0.0
+        assert result["limit_mb"] == 0.0
+        assert result["percent"] == 0  # Division by zero handled
+
+    def test_missing_memory_stats(self) -> None:
+        """Test calculating memory usage when memory_stats key is missing."""
+        stats = {"cpu_stats": {"online_cpus": 4}}
+
+        result = calculate_memory_usage(stats)
+
+        assert result["usage_bytes"] == 0
+        assert result["limit_bytes"] == 0
+        assert result["percent"] == 0
+
+    def test_zero_limit_prevents_division_error(self) -> None:
+        """Test that zero limit doesn't cause division by zero."""
+        stats = {
+            "memory_stats": {
+                "usage": 1000000,
+                "limit": 0,
+            }
+        }
+
+        result = calculate_memory_usage(stats)
+
+        assert result["usage_bytes"] == 1000000
+        assert result["limit_bytes"] == 0
+        assert result["percent"] == 0  # Should be 0, not ZeroDivisionError
+
+    def test_partial_memory_stats(self) -> None:
+        """Test calculating memory usage with partial memory_stats."""
+        stats = {
+            "memory_stats": {
+                "usage": 500000,
+                # limit is missing
+            }
+        }
+
+        result = calculate_memory_usage(stats)
+
+        assert result["usage_bytes"] == 500000
+        assert result["limit_bytes"] == 0
+        assert result["percent"] == 0
+
+    def test_very_large_values(self) -> None:
+        """Test with very large memory values (64GB container)."""
+        stats = {
+            "memory_stats": {
+                "usage": 68719476736,  # 64 GB
+                "limit": 137438953472,  # 128 GB
+            }
+        }
+
+        result = calculate_memory_usage(stats)
+
+        assert result["usage_bytes"] == 68719476736
+        assert result["limit_bytes"] == 137438953472
+        assert result["usage_mb"] == pytest.approx(65536.0)
+        assert result["limit_mb"] == pytest.approx(131072.0)
+        assert result["percent"] == pytest.approx(50.0)
+
+
+class TestCalculateCpuUsage:
+    """Tests for calculate_cpu_usage function."""
+
+    def test_normal_cpu_usage(self) -> None:
+        """Test calculating CPU usage with typical values."""
+        stats = {
+            "cpu_stats": {
+                "online_cpus": 4,
+                "cpu_usage": {
+                    "total_usage": 123456789,
+                },
+                "system_cpu_usage": 987654321,
+            }
+        }
+
+        result = calculate_cpu_usage(stats)
+
+        assert result["online_cpus"] == 4
+        assert result["total_usage"] == 123456789
+        assert result["system_usage"] == 987654321
+
+    def test_empty_stats(self) -> None:
+        """Test calculating CPU usage with empty stats."""
+        stats: dict = {}
+
+        result = calculate_cpu_usage(stats)
+
+        assert result["online_cpus"] == 1  # Default to 1 CPU
+        assert result["total_usage"] == 0
+        assert result["system_usage"] == 0
+
+    def test_missing_cpu_stats(self) -> None:
+        """Test calculating CPU usage when cpu_stats key is missing."""
+        stats = {"memory_stats": {"usage": 1000}}
+
+        result = calculate_cpu_usage(stats)
+
+        assert result["online_cpus"] == 1
+        assert result["total_usage"] == 0
+        assert result["system_usage"] == 0
+
+    def test_partial_cpu_stats(self) -> None:
+        """Test calculating CPU usage with partial cpu_stats."""
+        stats = {
+            "cpu_stats": {
+                "online_cpus": 8,
+                # cpu_usage and system_cpu_usage missing
+            }
+        }
+
+        result = calculate_cpu_usage(stats)
+
+        assert result["online_cpus"] == 8
+        assert result["total_usage"] == 0
+        assert result["system_usage"] == 0
+
+    def test_missing_cpu_usage_nested(self) -> None:
+        """Test when cpu_usage dict is present but total_usage is missing."""
+        stats = {
+            "cpu_stats": {
+                "online_cpus": 2,
+                "cpu_usage": {},  # Empty, no total_usage
+                "system_cpu_usage": 1000,
+            }
+        }
+
+        result = calculate_cpu_usage(stats)
+
+        assert result["online_cpus"] == 2
+        assert result["total_usage"] == 0
+        assert result["system_usage"] == 1000
+
+
+class TestFormatNetworkStats:
+    """Tests for format_network_stats function."""
+
+    def test_single_interface(self) -> None:
+        """Test formatting stats for a single network interface."""
+        stats = {
+            "networks": {
+                "eth0": {
+                    "rx_bytes": 1048576,  # 1 MB = 1024 KB
+                    "tx_bytes": 524288,  # 0.5 MB = 512 KB
+                }
+            }
+        }
+
+        result = format_network_stats(stats)
+
+        assert "eth0" in result
+        assert "RX 1024.00 KB" in result
+        assert "TX 512.00 KB" in result
+
+    def test_multiple_interfaces(self) -> None:
+        """Test formatting stats for multiple network interfaces."""
+        stats = {
+            "networks": {
+                "eth0": {"rx_bytes": 1024, "tx_bytes": 2048},
+                "eth1": {"rx_bytes": 4096, "tx_bytes": 8192},
+            }
+        }
+
+        result = format_network_stats(stats)
+
+        assert "eth0" in result
+        assert "eth1" in result
+        assert "RX 1.00 KB" in result  # eth0 rx
+        assert "RX 4.00 KB" in result  # eth1 rx
+
+    def test_no_network_interfaces(self) -> None:
+        """Test formatting when no network interfaces exist."""
+        stats = {"networks": {}}
+
+        result = format_network_stats(stats)
+
+        assert "No network interfaces" in result
+
+    def test_missing_networks_key(self) -> None:
+        """Test formatting when networks key is missing."""
+        stats: dict = {}
+
+        result = format_network_stats(stats)
+
+        assert "No network interfaces" in result
+
+    def test_partial_interface_stats(self) -> None:
+        """Test formatting with partial interface statistics."""
+        stats = {
+            "networks": {
+                "eth0": {
+                    "rx_bytes": 1000,
+                    # tx_bytes missing
+                }
+            }
+        }
+
+        result = format_network_stats(stats)
+
+        assert "eth0" in result
+        assert "RX" in result
+        assert "TX 0.00 KB" in result  # Default to 0
+
+    def test_zero_bytes(self) -> None:
+        """Test formatting with zero traffic."""
+        stats = {"networks": {"lo": {"rx_bytes": 0, "tx_bytes": 0}}}
+
+        result = format_network_stats(stats)
+
+        assert "lo" in result
+        assert "RX 0.00 KB" in result
+        assert "TX 0.00 KB" in result
+
+    def test_very_large_traffic(self) -> None:
+        """Test formatting with very large traffic values (10 GB)."""
+        stats = {
+            "networks": {
+                "eth0": {
+                    "rx_bytes": 10737418240,  # 10 GB
+                    "tx_bytes": 5368709120,  # 5 GB
+                }
+            }
+        }
+
+        result = format_network_stats(stats)
+
+        assert "eth0" in result
+        # 10 GB = 10485760 KB
+        assert "10485760.00 KB" in result


### PR DESCRIPTION
## Summary

- **Parameterize repetitive tests** using `@pytest.mark.parametrize` to reduce code duplication
- **Consolidate fixtures** from class-level to module-level to eliminate redundancy
- **Fix documentation issues** (outdated structure diagram, incorrect script references, version)
- **Add 51 new tests** for helper functions (fastmcp, http, stats formatter)

**Net reduction: 1,378 lines** (code + tests + docs)

## Test Refactoring

| File | Before | After | Saved |
|------|--------|-------|-------|
| test_fastmcp_tools_container_lifecycle.py | 845 | 485 | 360 |
| test_fastmcp_tools_image.py | 1062 | 692 | 370 |
| test_fastmcp_tools_network.py | 865 | 538 | 327 |
| test_fastmcp_tools_combined_metadata.py | 284 | 112 | 172 |
| test_safety_enforcement_e2e.py | 556 | 434 | 122 |
| test_protocol_validation_e2e.py | 362 | 274 | 88 |

## Documentation Fixes

- **README.md**: Fixed project structure diagram (now shows actual dirs: `fastmcp_tools/`, `docker_wrapper/`, etc.), corrected tool count (36→33), fixed E2E test command (`not slow`→`not stress`)
- **SECURITY.md**: Replaced non-existent script references (`start-mcp-docker-httpstream.sh`) with actual commands
- **CONFIGURATION.md**: Fixed CORS variable naming (`CORS_ALLOW_ORIGINS`→`CORS_ALLOWED_ORIGINS`)
- **docs/index.md**: Updated version to 1.2.2.dev0

## Test plan

- [x] All 960 tests pass (909 unit + 51 new)
- [x] Ruff check passes
- [x] Ruff format passes
- [x] mypy passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)