### PR TITLE
chore: Bump version to 1.2.3.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-docker"
-version = "1.2.2"
+version = "1.2.3.dev0"
 description = "Model Context Protocol server for Docker management with AI assistants"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- Bump version to 1.2.3.dev0 for development after v1.2.2 release

## Test plan

- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)