### PR TITLE
docs: Fix version display on GitHub Pages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -128,7 +128,7 @@ MIT License - see [LICENSE](https://github.com/williajm/mcp_docker/blob/main/LIC
 
 ---
 
-**Version**: 1.2.2.dev0
-**Last Updated**: 2025-11-25
+**Version**: 1.2.2
+**Last Updated**: 2025-11-29
 **Python**: 3.11+
 **Docker**: API version 1.41+


### PR DESCRIPTION
## Summary

- Update GitHub Pages to show released version `1.2.2` instead of `1.2.2.dev0`
- Update last updated date to 2025-11-29

## Test plan

- [x] Verify docs/index.md shows correct version
- [ ] After merge, confirm GitHub Pages displays `Version: 1.2.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)