### PR TITLE
fix: Add fastmcp and mcp to ClusterFuzzLite hidden imports

### DIFF
--- a/src/mcp_docker/auth/__init__.py
+++ b/src/mcp_docker/auth/__init__.py
@@ -2,6 +2,8 @@
 
 from mcp_docker.auth.models import ClientInfo
 from mcp_docker.auth.oauth_auth import OAuthAuthenticationError, OAuthAuthenticator
-from mcp_docker.middleware.auth import AuthMiddleware
 
-__all__ = ["ClientInfo", "AuthMiddleware", "OAuthAuthenticator", "OAuthAuthenticationError"]
+# Note: AuthMiddleware is available from mcp_docker.middleware.auth
+# Not re-exported here to avoid circular imports with fastmcp
+
+__all__ = ["ClientInfo", "OAuthAuthenticator", "OAuthAuthenticationError"]


### PR DESCRIPTION
## Summary

Fixes ClusterFuzzLite build failure after the package refactoring (#145).

The refactoring created a circular import chain that required `fastmcp` at module load time:
```
services/__init__ → audit.py → auth/__init__ → middleware/auth → fastmcp
```

## Root Cause

`auth/__init__.py` re-exported `AuthMiddleware` from `mcp_docker.middleware.auth`, which imports `fastmcp`. This caused the fuzz tests (which only need safety validation functions) to transitively require `fastmcp`.

## Fix

Remove the `AuthMiddleware` re-export from `auth/__init__.py`. Nothing was using `from mcp_docker.auth import AuthMiddleware` - all imports use `from mcp_docker.middleware.auth import AuthMiddleware` directly.

## Test plan

- [x] All 920 unit tests pass
- [x] mypy/ruff clean
- [ ] ClusterFuzzLite batch fuzzing passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)