### PR TITLE
chore(deps): Update dependencies and prepare v1.2.3 release

### DIFF
--- a/.github/requirements/pre-commit.txt
+++ b/.github/requirements/pre-commit.txt
@@ -13,8 +13,8 @@ virtualenv==20.35.4 \
     --hash=sha256:c21c9cede36c9753eeade68ba7d523529f228a403463376cf821eaae2b650f1b
 distlib==0.4.0 \
     --hash=sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16
-filelock==3.20.0 \
-    --hash=sha256:339b4732ffda5cd79b13f4e2711a31b0365ce445d95d243bb996273d072546a2
+filelock==3.20.1 \
+    --hash=sha256:15d9e9a67306188a44baa72f569d2bfd803076269365fdea0934385da4dc361a
 platformdirs==4.5.0 \
     --hash=sha256:e578a81bb873cbb89a41fcc904c7ef523cc18284b7e3b3ccf06aca1403b7ebd3
 typing-extensions==4.15.0 \

--- a/.github/workflows/cflite.yml
+++ b/.github/workflows/cflite.yml
@@ -76,7 +76,7 @@ jobs:
 
     - name: Upload SARIF results
       if: always() && steps.run.outputs.sarif != ''
-      uses: github/codeql-action/upload-sarif@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4.31.8
+      uses: github/codeql-action/upload-sarif@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9
       with:
         sarif_file: ${{ steps.run.outputs.sarif }}
         category: clusterfuzzlite-${{ matrix.sanitizer }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@f0c8eb29807907de7f5412d04afceb5e24817127 # v1.0.23
+        uses: anthropics/claude-code-action@d7b6d50442a89f005016e778bf825a72ef582525 # v1.0.25
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@f0c8eb29807907de7f5412d04afceb5e24817127 # v1.0.23
+        uses: anthropics/claude-code-action@d7b6d50442a89f005016e778bf825a72ef582525 # v1.0.25
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,16 +32,16 @@ jobs:
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4.31.8
+      uses: github/codeql-action/init@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9
       with:
         languages: ${{ matrix.language }}
         queries: +security-and-quality
         config-file: ./.github/codeql/codeql-config.yml
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4.31.8
+      uses: github/codeql-action/autobuild@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4.31.8
+      uses: github/codeql-action/analyze@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -45,6 +45,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4.31.8
+        uses: github/codeql-action/upload-sarif@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9
         with:
           sarif_file: results.sarif

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -448,3 +448,45 @@ explorer.exe htmlcov/index.html
 # See missing lines
 uv run pytest tests/unit/ --cov=mcp_docker --cov-report=term-missing
 ```
+
+### Preparing a Release
+
+**Files to update before releasing a new version:**
+
+1. **`pyproject.toml`** - Remove `.dev0` suffix from version (e.g., `1.2.3.dev0` → `1.2.3`)
+
+2. **`CHANGELOG.md`** - Add release section with:
+   - New version header with date: `## [X.Y.Z] - YYYY-MM-DD`
+   - Review git log since last release: `git log v{last_version}..HEAD --oneline`
+   - Categorize changes: Added, Changed, Fixed, Security, Documentation, Deprecated, Removed
+
+3. **`docs/index.md`** - Update footer:
+   - `**Version**: X.Y.Z`
+   - `**Last Updated**: YYYY-MM-DD`
+
+4. **README.md** - Update if tool/prompt/resource counts changed
+
+**Release checklist:**
+```bash
+# 1. Check commits since last release
+git log v1.2.2..HEAD --oneline
+
+# 2. Update all files above
+
+# 3. Run quality checks
+uv run ruff check src/ tests/
+uv run ruff format --check src/ tests/
+uv run mypy src/mcp_docker/
+uv run pytest tests/unit/ -v
+
+# 4. Commit and create PR
+git add -A
+git commit -m "chore: Prepare vX.Y.Z release"
+
+# 5. After merge, tag the release
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git push origin vX.Y.Z
+
+# 6. Immediately bump to next dev version
+# Edit pyproject.toml: version = "X.Y.(Z+1).dev0"
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.3] - 2025-12-21
+
+### Added
+- **Background Task Support**: Long-running Docker operations now report real-time progress (#169)
+  - `docker_pull_image`: Layer-by-layer progress with download percentages and MB sizes
+  - `docker_build_image`: Build step progress (Step 1/N, Step 2/N, etc.)
+  - `docker_push_image`: Layer-by-layer push progress with upload percentages
+  - Requires FastMCP 2.14.0+
+
+### Security
+- **X-Forwarded-For Support**: Proper trusted proxy handling for reverse proxy deployments (#159)
+  - Parses XFF header only when direct connection is from a trusted proxy
+  - Supports CIDR notation (e.g., `10.0.0.0/24`)
+  - Walks XFF chain right-to-left to find first non-trusted IP
+- **Audit Log Secret Redaction**: Automatically redacts sensitive fields before logging (#159)
+  - Redacts values for keys matching: password, token, secret, credential, auth, jwt, bearer, etc.
+- **filelock CVE-2025-68146**: Updated filelock 3.20.0 → 3.20.1 to fix TOCTOU race condition
+  - Prevents symlink attacks during lock file creation in pre-commit dependencies
+
+### Changed
+- **Package Structure Reorganized**: Cleaner module organization for clarity (#145)
+  - `server/` - MCP server, prompts, resources
+  - `tools/` - All tool implementations
+  - `services/` - Core services (safety, audit, rate limiting)
+  - `docker/` - Docker SDK wrapper
+  - `middleware/` - Auth middleware
+- **GitHub Actions Updated**:
+  - `github/codeql-action` 4.31.8 → 4.31.9
+  - `anthropics/claude-code-action` 1.0.23 → 1.0.25
+  - `actions/checkout` 6.0.0 → 6.0.1
+  - `actions/stale` 10.1.0 → 10.1.1
+  - `astral-sh/setup-uv` 7.1.4 → 7.1.5
+- **Dependencies Updated**: Python dependencies updated to latest versions (#158, #168)
+- **Removed Unused Config**: Removed `max_concurrent_operations` from SafetyConfig (#159)
+
+### Fixed
+- **Exec Truncation Metadata**: Changed `original_count/truncated_count` to `original_size/truncated_size` (#159)
+- **Loguru Private API**: Replaced `logger._core.min_level` with explicit `debug_enabled` parameter (#159)
+- **Circular Import Chain**: Fixed import cycle affecting ClusterFuzzLite fuzzing (#146)
+
+### Documentation
+- Updated SECURITY.md to accurately reflect implemented features (#159)
+- Removed claims about unimplemented TLS/CORS/security headers (use reverse proxy)
+- Added comprehensive X-Forwarded-For documentation with examples
+
 ## [1.2.2] - 2025-11-29
 
 ### Security

--- a/docs/index.md
+++ b/docs/index.md
@@ -128,7 +128,7 @@ MIT License - see [LICENSE](https://github.com/williajm/mcp_docker/blob/main/LIC
 
 ---
 
-**Version**: 1.2.2
-**Last Updated**: 2025-11-29
+**Version**: 1.2.3
+**Last Updated**: 2025-12-21
 **Python**: 3.11+
 **Docker**: API version 1.41+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-docker"
-version = "1.2.3.dev0"
+version = "1.2.3"
 description = "Model Context Protocol server for Docker management with AI assistants"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- Updates dependencies to fix security vulnerability and prepare for v1.2.3 release
- Supersedes Dependabot PRs #163 and #164

## Changes

### Security
- **filelock** 3.20.0 → 3.20.1 (fixes CVE-2025-68146 TOCTOU race condition)

### Dependencies
- **github/codeql-action** 4.31.8 → 4.31.9
- **anthropics/claude-code-action** 1.0.23 → 1.0.25

### Release Prep
- Bump version to 1.2.3
- Update CHANGELOG.md with full release notes
- Update docs/index.md version and date
- Add "Preparing a Release" checklist to CLAUDE.md

## Test plan

- [x] Pre-commit hooks pass
- [ ] CI passes
- [ ] Merge and tag v1.2.3
- [ ] Close Dependabot PRs #163 and #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)