### PR TITLE
chore: Bump version to 1.2.4.dev0 for development

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-docker"
-version = "1.2.3"
+version = "1.2.4.dev0"
 description = "Model Context Protocol server for Docker management with AI assistants"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Post-release version bump to 1.2.4.dev0 after tagging v1.2.3.

## Test plan

- [x] Pre-commit hooks pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)