### PR TITLE
chore: Remove dead code and fix incorrect docstrings

### DIFF
--- a/src/mcp_docker/tools/container_inspection.py
+++ b/src/mcp_docker/tools/container_inspection.py
@@ -407,11 +407,7 @@ def create_inspect_container_tool(
             logger.info(f"Inspecting container: {container_id}")
             container = docker_client.client.containers.get(container_id)
             container_info = container.attrs
-
-            # Apply output limits (truncate large fields)
             truncation_info: dict[str, Any] = {}
-            # Note: truncate_dict_fields would be imported if we use it
-            # For now, returning full info
 
             logger.info(f"Successfully inspected container: {container_id}")
 
@@ -526,7 +522,6 @@ def create_container_stats_tool(
 
     Args:
         docker_client: Docker client wrapper
-        safety_config: Safety configuration
 
     Returns:
         Tuple of (name, description, safety_level, idempotent, open_world,

--- a/src/mcp_docker/tools/image.py
+++ b/src/mcp_docker/tools/image.py
@@ -973,11 +973,7 @@ def create_inspect_image_tool(
             logger.info(f"Inspecting image: {image_name}")
             image = docker_client.client.images.get(image_name)
             details = image.attrs
-
-            # Apply output limits (truncate large fields)
             truncation_info: dict[str, Any] = {}
-            # Note: truncate_dict_fields would be imported if we use it
-            # For now, returning full info
 
             logger.info(f"Successfully inspected image: {image_name}")
 

--- a/src/mcp_docker/tools/network.py
+++ b/src/mcp_docker/tools/network.py
@@ -271,7 +271,6 @@ def create_inspect_network_tool(
 
     Args:
         docker_client: Docker client wrapper
-        safety_config: Safety configuration
 
     Returns:
         Tuple of (name, description, safety_level, idempotent, open_world,
@@ -297,11 +296,7 @@ def create_inspect_network_tool(
             logger.info(f"Inspecting network: {network_id}")
             network = docker_client.client.networks.get(network_id)
             details = network.attrs
-
-            # Apply output limits (truncate large fields)
             truncation_info: dict[str, Any] = {}
-            # Note: truncate_dict_fields would be imported if we use it
-            # For now, returning full info
 
             logger.info(f"Successfully inspected network: {network_id}")
 

--- a/src/mcp_docker/tools/volume.py
+++ b/src/mcp_docker/tools/volume.py
@@ -247,7 +247,6 @@ def create_inspect_volume_tool(
 
     Args:
         docker_client: Docker client wrapper
-        safety_config: Safety configuration
 
     Returns:
         Tuple of (name, description, safety_level, idempotent, open_world,
@@ -273,11 +272,7 @@ def create_inspect_volume_tool(
             logger.info(f"Inspecting volume: {volume_name}")
             volume = docker_client.client.volumes.get(volume_name)
             details = volume.attrs
-
-            # Apply output limits (truncate large fields)
             truncation_info: dict[str, Any] = {}
-            # Note: truncate_dict_fields would be imported if we use it
-            # For now, returning full info
 
             logger.info(f"Successfully inspected volume: {volume_name}")
 

--- a/uv.lock
+++ b/uv.lock
@@ -991,7 +991,7 @@ wheels = [
 
 [[package]]
 name = "mcp-docker"
-version = "1.2.3.dev0"
+version = "1.2.4.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
## Summary

- Remove placeholder comments referencing non-existent `truncate_dict_fields` function from inspect tools (container, image, network, volume)
- Fix docstrings documenting `safety_config` parameter that doesn't exist in `create_container_stats_tool`, `create_inspect_network_tool`, and `create_inspect_volume_tool`
- Update `uv.lock` to reflect current version (1.2.4.dev0)

## Test plan

- [x] All pre-commit hooks pass (ruff, mypy, cognitive-complexity)
- [ ] CI unit tests pass
- [ ] CI integration tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)