### PR TITLE
chore: Sync uv.lock with pyproject.toml

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -991,7 +991,7 @@ wheels = [
 
 [[package]]
 name = "mcp-docker"
-version = "1.2.3.dev0"
+version = "1.2.4.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
## Summary
- Updates uv.lock to sync with pyproject.toml version 1.2.4.dev0

## Test plan
- [x] Pre-commit hooks pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)