### PR TITLE
fix(security): Update authlib to 1.6.6 to address CVE-2025-68158

### DIFF
--- a/.clusterfuzzlite/requirements.txt
+++ b/.clusterfuzzlite/requirements.txt
@@ -27,8 +27,8 @@ cryptography==46.0.3 \
     --hash=sha256:01ca9ff2885f3acc98c29f1860552e37f6d7c7d013d7334ff2a9de43a449315d
 
 # OAuth/OIDC authentication dependencies (added in v1.1.0)
-authlib==1.6.5 \
-    --hash=sha256:3e0e0507807f842b02175507bdee8957a1d5707fd4afb17c32fb43fee90b6e3a
+authlib==1.6.6 \
+    --hash=sha256:7d9e9bc535c13974313a87f53e8430eb6ea3d1cf6ae4f6efcd793f2e949143fd
 
 httpx==0.28.1 \
     --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad


### PR DESCRIPTION
## Summary
- Updates authlib from 1.6.5 to 1.6.6 in ClusterFuzzLite requirements
- Fixes CVE-2025-68158: 1-click Account Takeover vulnerability (GHSA-fg6f-75jq-6523)
- Updates hash to match new version

## Test plan
- [ ] CI passes (ClusterFuzzLite build uses updated requirements)
- [ ] Dependabot alert auto-closes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)