### PR TITLE
chore: Bump version to 1.2.5.dev0 for development

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-docker"
-version = "1.2.4"
+version = "1.2.5.dev0"
 description = "Model Context Protocol server for Docker management with AI assistants"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -991,7 +991,7 @@ wheels = [
 
 [[package]]
 name = "mcp-docker"
-version = "1.2.4"
+version = "1.2.5.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
## Summary
- Bumps version from 1.2.4 to 1.2.5.dev0 for continued development

🤖 Generated with [Claude Code](https://claude.com/claude-code)