### PR TITLE
docs: Add PyPI stats link

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,8 +426,9 @@ mcp_docker/
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
-## Acknowledgments
+## Links
 
+- [PyPI Download Stats](https://pypi.kopdog.com/package/?name=mcp-docker)
 - Built with the [Model Context Protocol](https://modelcontextprotocol.io) by Anthropic
 - Uses the official [Docker SDK for Python](https://docker-py.readthedocs.io/)
 - Powered by modern Python tooling: [uv](https://github.com/astral-sh/uv), [ruff](https://github.com/astral-sh/ruff), [mypy](https://mypy-lang.org/), [pytest](https://pytest.org/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ Repository = "https://github.com/williajm/mcp_docker"
 PyPI = "https://pypi.org/project/mcp-docker/"
 Issues = "https://github.com/williajm/mcp_docker/issues"
 Changelog = "https://github.com/williajm/mcp_docker/releases"
+Stats = "https://pypi.kopdog.com/package/?name=mcp-docker"
 
 [project.scripts]
 mcp-docker = "mcp_docker.__main__:app"


### PR DESCRIPTION
## Summary
- Adds Stats URL to `pyproject.toml` `[project.urls]` (displays on PyPI page)
- Renames "Acknowledgments" to "Links" in README and adds stats link

🤖 Generated with [Claude Code](https://claude.com/claude-code)