### PR TITLE
docs: Add PyPI stats link to GitHub Pages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -125,6 +125,7 @@ MIT License - see [LICENSE](https://github.com/williajm/mcp_docker/blob/main/LIC
 - **Issues**: [GitHub Issues](https://github.com/williajm/mcp_docker/issues)
 - **Discussions**: [GitHub Discussions](https://github.com/williajm/mcp_docker/discussions)
 - **MCP Documentation**: [modelcontextprotocol.io](https://modelcontextprotocol.io)
+- **PyPI Download Stats**: [pypi.kopdog.com](https://pypi.kopdog.com/package/?name=mcp-docker)
 
 ---
 


### PR DESCRIPTION
## Summary
- Add PyPI Download Stats link to the Support section of the GitHub Pages site
- Matches the link already present in the main README

## Test plan
- [ ] Verify the link renders correctly on the GitHub Pages site after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)