### PR TITLE
security: Fix urllib3 CVE-2026-21441 + prepare v1.2.6 release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  # GitHub Actions - security updates only
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0  # No version PRs, security PRs still created
+
+  # Python dependencies - security updates only
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0  # No version PRs, security PRs still created

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.6] - 2026-01-19
+
+### Security
+- **urllib3 CVE-2026-21441**: Updated urllib3 2.6.1 → 2.6.3 (HIGH severity)
+  - Fixes decompression-bomb safeguards bypass when following HTTP redirects (streaming API)
+- **filelock CVE**: Updated filelock 3.20.1 → 3.20.3
+  - Fixes Time-of-Check-Time-of-Use (TOCTOU) symlink vulnerability
+- **virtualenv CVE**: Updated virtualenv 20.35.4 → 20.36.1
+  - Fixes TOCTOU vulnerabilities in directory creation
+
+### Changed
+- **GitHub Actions Updated**:
+  - `actions/cache` 5.0.1 → 5.0.2
+  - `anthropics/claude-code-action` 1.0.29 → 1.0.30
+- **Dependabot Security-Only**: Version update PRs disabled (`open-pull-requests-limit: 0`); security PRs still created automatically
+
 ## [1.2.5] - 2026-01-13
 
 ### Security

--- a/docs/index.md
+++ b/docs/index.md
@@ -129,7 +129,7 @@ MIT License - see [LICENSE](https://github.com/williajm/mcp_docker/blob/main/LIC
 
 ---
 
-**Version**: 1.2.5
-**Last Updated**: 2026-01-13
+**Version**: 1.2.6
+**Last Updated**: 2026-01-19
 **Python**: 3.11+
 **Docker**: API version 1.41+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-docker"
-version = "1.2.6.dev0"
+version = "1.2.6"
 description = "Model Context Protocol server for Docker management with AI assistants"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -2123,11 +2123,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.1"
+version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/1d/0f3a93cca1ac5e8287842ed4eebbd0f7a991315089b1a0b01c7788aa7b63/urllib3-2.6.1.tar.gz", hash = "sha256:5379eb6e1aba4088bae84f8242960017ec8d8e3decf30480b3a1abdaa9671a3f", size = 432678, upload-time = "2025-12-08T15:25:26.773Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/56/190ceb8cb10511b730b564fb1e0293fa468363dbad26145c34928a60cb0c/urllib3-2.6.1-py3-none-any.whl", hash = "sha256:e67d06fe947c36a7ca39f4994b08d73922d40e6cca949907be05efa6fd75110b", size = 131138, upload-time = "2025-12-08T15:25:25.51Z" },
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Upgrade `urllib3` 2.6.1 → 2.6.3 (CVE-2026-21441)
- Prepare v1.2.6 release files
- Re-enable Dependabot with security-only config

## Security

| CVE | Severity | Issue |
|-----|----------|-------|
| CVE-2026-21441 | HIGH | Decompression-bomb safeguards bypassed when following HTTP redirects (streaming API) |

## Release Files Updated

- `pyproject.toml`: 1.2.6.dev0 → 1.2.6
- `CHANGELOG.md`: Added [1.2.6] section
- `docs/index.md`: Updated version and date

## Dependabot Config

- `open-pull-requests-limit: 0` for both pip and github-actions
- Version update PRs: disabled
- Security PRs: still auto-created

## Test plan

- [x] `uv lock --upgrade-package urllib3` completed
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)