### PR TITLE
security: Fix CVE-2026-24486 python-multipart path traversal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "httpx>=0.28.1",
     "typer>=0.20.0",
     "humanfriendly>=10.0",
+    "python-multipart>=0.0.22",  # CVE-2026-24486: Path traversal fix
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -991,7 +991,7 @@ wheels = [
 
 [[package]]
 name = "mcp-docker"
-version = "1.2.6.dev0"
+version = "1.2.7.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },
@@ -1004,6 +1004,7 @@ dependencies = [
     { name = "loguru" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "python-multipart" },
     { name = "secure" },
     { name = "starlette" },
     { name = "typer" },
@@ -1065,6 +1066,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-docker", marker = "extra == 'dev'", specifier = ">=3.2.5" },
+    { name = "python-multipart", specifier = ">=0.0.22" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.9" },
     { name = "secure", specifier = ">=1.0.1" },
     { name = "starlette", specifier = ">=0.50.0" },
@@ -1624,11 +1626,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.20"
+version = "0.0.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158, upload-time = "2024-12-16T19:45:46.972Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546, upload-time = "2024-12-16T19:45:44.423Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Upgrade python-multipart from 0.0.20 to 0.0.22
- Fixes CVE-2026-24486: High severity (CVSS 8.6) path traversal vulnerability
- Vulnerability allowed writing uploaded files to arbitrary filesystem locations

## Test plan
- [ ] CI passes (unit, integration, E2E tests)
- [ ] Verify python-multipart version in lockfile is 0.0.22

🤖 Generated with [Claude Code](https://claude.com/claude-code)