### PR TITLE
fix: upgrade Pygments to 2.20.0

### DIFF
--- a/.github/requirements/bandit.txt
+++ b/.github/requirements/bandit.txt
@@ -9,8 +9,8 @@ markdown-it-py==4.0.0 \
     --hash=sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147
 mdurl==0.1.2 \
     --hash=sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8
-Pygments==2.19.2 \
-    --hash=sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b
+Pygments==2.20.0 \
+    --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
 rich==14.2.0 \
     --hash=sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd
 # PyYAML with hashes for all supported platforms (Python 3.10-3.13)


### PR DESCRIPTION
## Summary
- Upgrades Pygments from 2.19.2 to 2.20.0 in `.github/requirements/bandit.txt`
- Resolves CVE-2026-4539 (Low)
- Addresses Dependabot security alert

## Test plan
- [x] Verified Pygments 2.20.0 with correct hash in bandit.txt
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)