### PR TITLE
security: Upgrade fastmcp 3.1.1 → 3.2.0 (CVE-2026-32871)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "fastmcp>=3.1.1",
+    "fastmcp>=3.2.0",  # CVE-2026-32871: SSRF & Path Traversal fix
     "docker>=7.1.0",
     "pydantic>=2.12.5",
     "pydantic-settings>=2.13.1",

--- a/uv.lock
+++ b/uv.lock
@@ -585,7 +585,7 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.1.1"
+version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -610,9 +610,9 @@ dependencies = [
     { name = "watchfiles" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/83/c95d3bf717698a693eccb43e137a32939d2549876e884e246028bff6ecce/fastmcp-3.1.1.tar.gz", hash = "sha256:db184b5391a31199323766a3abf3a8bfbb8010479f77eca84c0e554f18655c48", size = 17347644, upload-time = "2026-03-14T19:12:20.235Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/32/4f1b2cfd7b50db89114949f90158b1dcc2c92a1917b9f57c0ff24e47a2f4/fastmcp-3.2.0.tar.gz", hash = "sha256:d4830b8ffc3592d3d9c76dc0f398904cf41f04910e41a0de38cc1004e0903bef", size = 26318581, upload-time = "2026-03-30T20:25:37.692Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/ea/570122de7e24f72138d006f799768e14cc1ccf7fcb22b7750b2bd276c711/fastmcp-3.1.1-py3-none-any.whl", hash = "sha256:8132ba069d89f14566b3266919d6d72e2ec23dd45d8944622dca407e9beda7eb", size = 633754, upload-time = "2026-03-14T19:12:22.736Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/67/684fa2d2de1e7504549d4ca457b4f854ccec3cd3be03bd86b33b599fbf58/fastmcp-3.2.0-py3-none-any.whl", hash = "sha256:e71aba3df16f86f546a4a9e513261d3233bcc92bef0dfa647bac3fa33623f681", size = 705550, upload-time = "2026-03-30T20:25:35.499Z" },
 ]
 
 [[package]]
@@ -1024,7 +1024,7 @@ requires-dist = [
     { name = "authlib", specifier = ">=1.6.9" },
     { name = "cachetools", specifier = ">=7.0.5" },
     { name = "docker", specifier = ">=7.1.0" },
-    { name = "fastmcp", specifier = ">=3.1.1" },
+    { name = "fastmcp", specifier = ">=3.2.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28.1" },
     { name = "httpx-sse", marker = "extra == 'dev'", specifier = ">=0.4.3" },


### PR DESCRIPTION
## Summary
- Upgrades fastmcp from 3.1.1 to 3.2.0 to resolve CVE-2026-32871 / GHSA-vv7q-7jx5-f767 (SSRF & Path Traversal in OpenAPI Provider)
- This repo doesn't use the vulnerable `OpenAPIProvider` feature, but 3.2.0 includes a broader security hardening pass (restricted `$ref` resolution, path traversal prevention in skill downloads, JWT algorithm fixes, PyJWT upgrade for CVE-2026-32597)

## Test plan
- [ ] CI passes
- [ ] Verify MCP server starts and tools register correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)