### PR TITLE
security: Add uv dependency cooldown (exclude-newer P3D)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,9 @@ exclude = [
     "CLAUDE.md",
 ]
 
+[tool.uv]
+exclude-newer = "P3D"  # Supply chain safety: avoid packages published < 3 days ago
+
 [tool.ruff]
 line-length = 100
 target-version = "py311"


### PR DESCRIPTION
## Summary
- Adds `exclude-newer = "P3D"` to `[tool.uv]` in pyproject.toml
- Enforces a 3-day cooldown on newly published PyPI packages, giving the community time to detect and quarantine compromised releases
- Prompted by the [PyPI litellm/telnyx supply chain attack incident report](https://blog.pypi.org/posts/2026-04-02-incident-report-litellm-telnyx-supply-chain-attack/) (2026-04-02)

The CLAUDE.md already documented the manual `uv lock --exclude-newer` approach — this makes it automatic for all `uv` operations.

## Test plan
- [ ] Verify `uv sync --locked` still works in CI (no change to lockfile)
- [ ] Verify `uv lock` respects the cooldown when regenerating the lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)