### PR TITLE
security: Bump authlib and python-multipart for Dependabot alerts

### DIFF
--- a/.clusterfuzzlite/requirements.txt
+++ b/.clusterfuzzlite/requirements.txt
@@ -23,12 +23,12 @@ pydantic-settings==2.6.1 \
 loguru==0.7.3 \
     --hash=sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c
 
-cryptography==46.0.6 \
-    --hash=sha256:9a693028b9cbe51b5a1136232ee8f2bc242e4e19d456ded3fa7c86e43c713b4a
+cryptography==46.0.7 \
+    --hash=sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308
 
 # OAuth/OIDC authentication dependencies (added in v1.1.0)
-authlib==1.6.9 \
-    --hash=sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3
+authlib==1.6.11 \
+    --hash=sha256:c8687a9a26451c51a34a06fa17bb97cb15bba46a6a626755e2d7f50da8bff3e3
 
 httpx==0.28.1 \
     --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
@@ -56,8 +56,8 @@ annotated-types==0.7.0 \
 typing-extensions==4.15.0 \
     --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
 
-python-dotenv==1.2.1 \
-    --hash=sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61
+python-dotenv==1.2.2 \
+    --hash=sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a
 
 cffi==2.0.0 \
     --hash=sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,10 +46,10 @@ dependencies = [
     "limits>=5.8.0",
     "cachetools>=7.0.5",
     "secure>=1.0.1",
-    "authlib>=1.6.9",
+    "authlib>=1.6.11",  # GHSA-jj8c-mmj3-mmgv
     "httpx>=0.28.1",
     "typer>=0.24.1",
-    "python-multipart>=0.0.22",  # CVE-2026-24486: Path traversal fix
+    "python-multipart>=0.0.26",  # CVE-2026-24486 / CVE-2026-40347: Path traversal fix
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2,9 +2,6 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 
-[options]
-exclude-newer = "2026-04-19T00:00:00Z"
-
 [[package]]
 name = "aiofile"
 version = "3.9.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,9 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 
+[options]
+exclude-newer = "2026-04-19T00:00:00Z"
+
 [[package]]
 name = "aiofile"
 version = "3.9.0"
@@ -67,14 +70,15 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.9"
+version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
+    { name = "joserfc" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/98/00d3dd826d46959ad8e32af2dbb2398868fd9fd0683c26e56d0789bd0e68/authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04", size = 165134, upload-time = "2026-03-02T07:44:01.998Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/82/4d0603f30c1b4629b1f091bb266b0d7986434891d6940a8c87f8098db24e/authlib-1.7.0.tar.gz", hash = "sha256:b3e326c9aa9cc3ea95fe7d89fd880722d3608da4d00e8a27e061e64b48d801d5", size = 175890, upload-time = "2026-04-18T11:00:28.559Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/23/b65f568ed0c22f1efacb744d2db1a33c8068f384b8c9b482b52ebdbc3ef6/authlib-1.6.9-py2.py3-none-any.whl", hash = "sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3", size = 244197, upload-time = "2026-03-02T07:44:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/48/c954218b2a250e23f178f10167c4173fecb5a75d2c206f0a67ba58006c26/authlib-1.7.0-py2.py3-none-any.whl", hash = "sha256:e36817afb02f6f0b6bf55f150782499ddd6ddf44b402bb055d3263cc65ac9ae0", size = 258779, upload-time = "2026-04-18T11:00:26.64Z" },
 ]
 
 [[package]]
@@ -759,6 +763,18 @@ wheels = [
 ]
 
 [[package]]
+name = "joserfc"
+version = "1.6.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/c6/de8fdbdfa75c8ca04fead38a82d573df8a82906e984c349d58665f459558/joserfc-1.6.4.tar.gz", hash = "sha256:34ce5f499bfcc5e9ad4cc75077f9278ab3227b71da9aaf28f9ab705f8a560d3c", size = 231866, upload-time = "2026-04-13T13:15:40.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/f7/210b27752e972edb36d239315b08d3eb6b14824cc4a590da2337d195260b/joserfc-1.6.4-py3-none-any.whl", hash = "sha256:3e4a22b509b41908989237a045e25c8308d5fd47ab96bdae2dd8057c6451003a", size = 70464, upload-time = "2026-04-13T13:15:39.259Z" },
+]
+
+[[package]]
 name = "jsonref"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1021,7 +1037,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "atheris", marker = "extra == 'dev'", specifier = ">=3.0.0" },
-    { name = "authlib", specifier = ">=1.6.9" },
+    { name = "authlib", specifier = ">=1.6.11" },
     { name = "cachetools", specifier = ">=7.0.5" },
     { name = "docker", specifier = ">=7.1.0" },
     { name = "fastmcp", specifier = ">=3.2.0" },
@@ -1038,7 +1054,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-docker", marker = "extra == 'dev'", specifier = ">=3.2.5" },
-    { name = "python-multipart", specifier = ">=0.0.22" },
+    { name = "python-multipart", specifier = ">=0.0.26" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.7" },
     { name = "secure", specifier = ">=1.0.1" },
     { name = "starlette", specifier = ">=0.52.1" },
@@ -1467,11 +1483,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.26"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Resolves **all 5 open Dependabot alerts** on mcp_docker:

| # | Package | Manifest | Change |
|---|---|---|---|
| 25 | python-multipart | `uv.lock` | 0.0.22 → 0.0.26 (CVE-2026-40347) |
| 27 | authlib | `uv.lock` | 1.6.9 → 1.7.0 (GHSA-jj8c-mmj3-mmgv) |
| 23 | cryptography | `.clusterfuzzlite/requirements.txt` | 46.0.6 → 46.0.7 (CVE-2026-39892) |
| 26 | authlib | `.clusterfuzzlite/requirements.txt` | 1.6.9 → 1.6.11 (GHSA-jj8c-mmj3-mmgv) |
| 28 | python-dotenv | `.clusterfuzzlite/requirements.txt` | 1.2.1 → 1.2.2 (CVE-2026-28684) |

## Notes

- **authlib version divergence**: `uv.lock` resolves to **1.7.0** (latest stable) while `.clusterfuzzlite/requirements.txt` is pinned at **1.6.11**. Both include the same security fix. The fuzzer stays on 1.6.11 to avoid adding `joserfc 1.6.4` as a new hash-pinned transitive dep — the fuzzer doesn't exercise code paths that require joserfc.
- `uv.lock` regenerated without `--exclude-newer` (an earlier iteration of this PR embedded an `[options] exclude-newer` block that tripped CI's `--locked` sync — fixed in commit a7a2ae6).
- Fuzzer hashes pulled from PyPI JSON API, matching the existing wheel variants (cp311 abi3 manylinux2014_x86_64 for cryptography; pure-python wheels for authlib and python-dotenv).

## Test plan
- [ ] CI green across Python 3.11/3.12/3.13/3.14
- [ ] `Integration Tests` / `E2E Tests` pass (auth middleware under authlib 1.7.0)
- [ ] `PR Fuzzing (address)` completes successfully (fuzz harness builds with new hash-pinned deps)
- [ ] `Batch Fuzzing` + `Dependency Review` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)